### PR TITLE
fix(docs[spa]): Fix prompt copy buttons surviving SPA navigation

### DIFF
--- a/docs/_static/js/prompt-copy.js
+++ b/docs/_static/js/prompt-copy.js
@@ -4,8 +4,19 @@
  * sphinx-copybutton uses innerText which strips HTML. This script
  * intercepts copy on .admonition.prompt buttons and reconstructs
  * inline markdown (backtick-wrapping <code> elements) before copying.
+ *
+ * Uses event delegation on document (capture phase) so it survives
+ * SPA navigation DOM swaps without re-initialization.
  */
 (function () {
+  // Same green checkmark SVG that sphinx-copybutton uses (copybutton.js:61-65)
+  var iconCheck =
+    '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-check" width="44" height="44" viewBox="0 0 24 24" stroke-width="2" stroke="#22863a" fill="none" stroke-linecap="round" stroke-linejoin="round">' +
+    "<title>Copied!</title>" +
+    '<path stroke="none" d="M0 0h24v24H0z" fill="none"/>' +
+    '<path d="M5 12l5 5l10 -10" />' +
+    "</svg>";
+
   function toMarkdown(el) {
     var text = "";
     for (var i = 0; i < el.childNodes.length; i++) {
@@ -23,41 +34,65 @@
     return text;
   }
 
-  function init() {
-    var buttons = document.querySelectorAll(
-      "div.admonition.prompt button.copybtn"
-    );
-    buttons.forEach(function (btn) {
-      btn.addEventListener(
-        "click",
-        function (e) {
-          e.stopImmediatePropagation();
-          e.preventDefault();
+  // Match sphinx-copybutton's exact feedback:
+  // icon swap + tooltip + .success class with staggered timeouts
+  function showCopySuccess(btn) {
+    var savedIcon = btn.innerHTML;
+    btn.innerHTML = iconCheck;
+    btn.setAttribute("data-tooltip", "Copied!");
+    btn.classList.add("success");
+    setTimeout(function () {
+      btn.classList.remove("success");
+    }, 1500);
+    setTimeout(function () {
+      btn.innerHTML = savedIcon;
+      btn.setAttribute("data-tooltip", "Copy");
+    }, 2000);
+  }
 
-          var targetId = btn.getAttribute("data-clipboard-target");
-          var target = document.querySelector(targetId);
-          if (!target) return;
+  // Single delegated listener on document (capture phase).
+  // Runs before ClipboardJS's bubble-phase delegation.
+  // Detects prompt buttons by checking where their data-clipboard-target
+  // points, not by button ancestry (buttons are siblings of the prompt
+  // div, not descendants — inserted by insertAdjacentHTML('afterend')).
+  document.addEventListener(
+    "click",
+    function (e) {
+      var btn = e.target.closest(".copybtn");
+      if (!btn) return;
 
-          var markdown = toMarkdown(target);
-          navigator.clipboard.writeText(markdown).then(function () {
-            btn.setAttribute("data-tooltip", "Copied!");
-            btn.classList.add("success");
-            setTimeout(function () {
-              btn.setAttribute("data-tooltip", "Copy");
-              btn.classList.remove("success");
-            }, 2000);
-          });
+      var targetId = btn.getAttribute("data-clipboard-target");
+      if (!targetId) {
+        console.warn("prompt-copy: copybtn has no data-clipboard-target");
+        return;
+      }
+
+      var target = document.querySelector(targetId);
+      if (!target) {
+        console.warn("prompt-copy: target not found:", targetId);
+        return;
+      }
+
+      // Only intercept if the target is inside a prompt admonition
+      if (!target.closest("div.admonition.prompt")) return;
+
+      e.stopImmediatePropagation();
+      e.preventDefault();
+
+      var markdown = toMarkdown(target);
+      navigator.clipboard.writeText(markdown).then(
+        function () {
+          showCopySuccess(btn);
         },
-        true
+        function (err) {
+          console.warn("prompt-copy: clipboard write failed:", err);
+          btn.setAttribute("data-tooltip", "Failed to copy");
+          setTimeout(function () {
+            btn.setAttribute("data-tooltip", "Copy");
+          }, 2000);
+        }
       );
-    });
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", function () {
-      setTimeout(init, 100);
-    });
-  } else {
-    setTimeout(init, 100);
-  }
+    },
+    true
+  );
 })();

--- a/docs/_static/js/spa-nav.js
+++ b/docs/_static/js/spa-nav.js
@@ -26,27 +26,58 @@
   }
 
   // --- Copy button injection ---
+  //
+  // Matches sphinx-copybutton's button HTML and selector so buttons work
+  // identically after SPA navigation.  Uses an inline template instead of
+  // cloning an existing button — the initial page may have no code blocks
+  // (e.g. index.html), leaving nothing to clone.
 
-  var copyBtnTemplate = null;
+  var iconCopy =
+    '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-copy" ' +
+    'width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" ' +
+    'fill="none" stroke-linecap="round" stroke-linejoin="round">' +
+    "<title>Copy to clipboard</title>" +
+    '<path stroke="none" d="M0 0h24v24H0z" fill="none"/>' +
+    '<rect x="8" y="8" width="12" height="12" rx="2" />' +
+    '<path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />' +
+    "</svg>";
 
-  function captureCopyIcon() {
-    var btn = document.querySelector(".copybtn");
-    if (btn) copyBtnTemplate = btn.cloneNode(true);
+  function makeCopyButton(targetId) {
+    return (
+      '<button class="copybtn o-tooltip--left" data-tooltip="Copy" ' +
+      'data-clipboard-target="#' +
+      targetId +
+      '">' +
+      iconCopy +
+      "</button>"
+    );
   }
 
   function addCopyButtons() {
-    if (!copyBtnTemplate) captureCopyIcon();
-    if (!copyBtnTemplate) return;
+    // Code blocks
     var cells = document.querySelectorAll("div.highlight pre");
     cells.forEach(function (cell, i) {
-      cell.id = "codecell" + i;
+      var id = "codecell" + i;
+      cell.id = id;
       var next = cell.nextElementSibling;
       if (next && next.classList.contains("copybtn")) {
-        next.setAttribute("data-clipboard-target", "#codecell" + i);
+        next.setAttribute("data-clipboard-target", "#" + id);
       } else {
-        var btn = copyBtnTemplate.cloneNode(true);
-        btn.setAttribute("data-clipboard-target", "#codecell" + i);
-        cell.insertAdjacentElement("afterend", btn);
+        cell.insertAdjacentHTML("afterend", makeCopyButton(id));
+      }
+    });
+    // Prompt blocks — match sphinx-copybutton's copybutton_selector
+    var prompts = document.querySelectorAll(
+      "div.admonition.prompt > p:last-child"
+    );
+    prompts.forEach(function (p, i) {
+      var id = "promptcell" + i;
+      p.id = id;
+      var next = p.nextElementSibling;
+      if (next && next.classList.contains("copybtn")) {
+        next.setAttribute("data-clipboard-target", "#" + id);
+      } else {
+        p.insertAdjacentHTML("afterend", makeCopyButton(id));
       }
     });
   }
@@ -247,8 +278,6 @@
 
   // --- Init ---
 
-  // Copy buttons are injected by copybutton.js on DOMContentLoaded.
-  // This defer script runs before DOMContentLoaded, so our handler
-  // fires after copybutton's handler (registration order preserved).
-  document.addEventListener("DOMContentLoaded", captureCopyIcon);
+  // No DOMContentLoaded setup needed for copy buttons — addCopyButtons()
+  // creates buttons from an inline template, independent of the initial page.
 })();


### PR DESCRIPTION
## Summary

- Fix prompt copy buttons breaking after SPA navigation
- Replace clone-based button creation with inline HTML template matching sphinx-copybutton's exact output
- Switch prompt-copy.js from direct event binding to document-level event delegation (capture phase)
- Match sphinx-copybutton's exact success feedback (green checkmark SVG swap + staggered timeouts)

### Root causes fixed

1. **No buttons after SPA nav from index.html**: `addCopyButtons()` cloned an existing `.copybtn` as template — but index.html has no code blocks, so the template was always null when landing there first. Replaced with inline HTML template.

2. **Prompt blocks skipped**: `addCopyButtons()` only created buttons for `div.highlight pre` (code blocks), not `div.admonition.prompt > p:last-child` (prompts). Added prompt block handling.

3. **Event listeners destroyed by DOM swap**: prompt-copy.js used direct `addEventListener` on each button — destroyed when SPA navigation replaced `.article-container`. Switched to document-level event delegation in capture phase.

4. **Wrong button detection selector**: `.closest("div.admonition.prompt .copybtn")` assumed button was a descendant of the prompt div. sphinx-copybutton inserts buttons via `insertAdjacentHTML('afterend')` making them siblings. Fixed by checking where `data-clipboard-target` points instead.

5. **Missing success feedback**: prompt-copy.js only did tooltip+class, not the SVG icon swap to green checkmark. Now matches sphinx-copybutton's exact behavior.

## Test plan

- [ ] Load `index.html`, SPA-navigate to Quickstart via sidebar — copy buttons appear on all code blocks and prompt blocks
- [ ] Click a prompt copy button with inline code — green checkmark appears, clipboard contains markdown with backticks
- [ ] SPA-navigate away and back — prompt copy buttons still work
- [ ] Direct-load a page with prompts (e.g. `/recipes/`) — copy buttons work on first load
- [ ] Code block copy buttons still work identically before and after SPA nav