### PR TITLE
chore(deps): bump libtmux floor to 0.55.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,16 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+- Minimum `libtmux>=0.55.1` (was `>=0.55.0`). 0.55.1 ships the
+  pytest-plugin socket-reaper fix
+  ([tmux-python/libtmux#661](https://github.com/tmux-python/libtmux/pull/661))
+  so `libtmux_test*` daemons and socket files no longer leak under
+  `/tmp/tmux-<uid>/` during test runs. Downstream effect: no local
+  conftest reaper is needed in libtmux-mcp — the upstream fixtures
+  self-clean.
+
 ## libtmux-mcp 0.1.0a2 (2026-04-19)
 
 _FastMCP alignment: new tools, prompts, and middleware (#15)_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ include = [
 ]
 
 dependencies = [
-  "libtmux>=0.55.0,<1.0",
+  "libtmux>=0.55.1,<1.0",
   "fastmcp>=3.2.4,<4.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1057,11 +1057,11 @@ wheels = [
 
 [[package]]
 name = "libtmux"
-version = "0.55.0"
+version = "0.55.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/85/99932ac9ddb90821778f8cabe32b81bbbec280dd1a14a457c512693fb11b/libtmux-0.55.0.tar.gz", hash = "sha256:cdc4aa564b2325618d73d57cb0d7d92475d02026dba2b96a94f87ad328e7e79d", size = 420859, upload-time = "2026-03-08T00:57:55.788Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/01/fa4f839045d32576d4c193d85ba37e47908fea8227f18800847f589e2476/libtmux-0.55.1.tar.gz", hash = "sha256:dcee950537b8bda4337267bc2cb62b434c4c8da3a75c1546151674238ef14e20", size = 439372, upload-time = "2026-04-19T18:25:39.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/34/b11ab24abb78c73a1b82f6471c2d71bdd1bf2c8f30768ed2f26f1dddc083/libtmux-0.55.0-py3-none-any.whl", hash = "sha256:4b746533856e022c759e5c5cae97f4932e85dae316a2afd4391d6d0e891d6ab8", size = 80094, upload-time = "2026-03-08T00:57:54.141Z" },
+    { url = "https://files.pythonhosted.org/packages/12/2e/819d7414b96f19ec4cafda95555246bdb9766dd7c0519b5b1bf4495789f7/libtmux-0.55.1-py3-none-any.whl", hash = "sha256:4382667d508610bdf71a7cc07d7a561d402fa2d5621cce299e7ae97b0cdcb93b", size = 80679, upload-time = "2026-04-19T18:25:37.61Z" },
 ]
 
 [[package]]
@@ -1124,7 +1124,7 @@ testing = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.2.4,<4.0.0" },
-    { name = "libtmux", specifier = ">=0.55.0,<1.0" },
+    { name = "libtmux", specifier = ">=0.55.1,<1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Bump the runtime floor of `libtmux` from `>=0.55.0` to `>=0.55.1` and refresh `uv.lock` to install 0.55.1.

libtmux 0.55.1 ships the pytest-plugin socket-reaper fix ([tmux-python/libtmux#661](https://github.com/tmux-python/libtmux/pull/661)): the `server` and `TestServer` fixtures now kill the tmux daemon AND unlink the socket file under `/tmp/tmux-<uid>/` on teardown. That's the upstream root-cause fix for the test-socket leak reported in #20.

## Effect on open PRs

**Supersedes #23 (local conftest reaper).** The local reaper was a downstream workaround for the same issue #661 fixes upstream. Once this bump lands, PR #23's fixture adds no behavior beyond what libtmux already does on teardown — it becomes pure churn. Recommend closing #23 without merge.

Unaffected: #21 (async channel waits), #22 (is_caller socket scope). Both are libtmux-mcp-only bugs with no upstream analog.

## Test plan

- [x] `uv run ruff check . --fix --show-fixes`
- [x] `uv run ruff format .`
- [x] `uv run mypy`
- [x] `uv run py.test --reruns 0 -vvv` (363 passed)
- [x] `just build-docs`

End-to-end verification: after the bump, a clean `uv run pytest` from an empty `/tmp/tmux-<uid>/libtmux_test*` state leaves **1 residual socket** (down from thousands accumulating across runs pre-fix). The lone straggler originates outside the standard fixture teardown path — a separate, minor issue, tracked separately if it matters.

## Companion PRs

- #21 — event-loop block in channel waits (closes #18, unaffected)
- #22 — `is_caller` socket-blind false positive (closes #19, unaffected)
- ~~#23~~ — local reaper (closes #20) — **superseded by this PR, close without merge**
- Upstream: [tmux-python/libtmux#661](https://github.com/tmux-python/libtmux/pull/661) — shipped in libtmux 0.55.1