### PR TITLE
scripts(mcp_swap): add --scope {user,project} for Claude two-layer config

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,9 +16,15 @@ _Notes on upcoming releases will be added here_
   Gemini have no per-project layer; the flag is silently coerced to
   `user` for them. A single install can hold both scopes
   simultaneously with independent backups, and `revert --scope user`
-  restores just one layer. State-file schema bumps to v2 (keys are
-  `cli:scope`) with transparent migration of v1 entries on load.
-  (#???)
+  restores just one layer. Full `revert` unwinds in LIFO order via an
+  explicit `seq_no` counter on each state entry — no reliance on dict
+  iteration through the JSON round-trip. Shape validation is
+  centralised in `_claude_user_servers` / `_claude_project_node`
+  helpers so read / write / delete fail symmetrically with
+  `RuntimeError` on a malformed Claude config. The state-file schema
+  is internal — no compatibility contract; running an older `mcp_swap`
+  against a newer `state.json` is undefined behaviour and not
+  supported. (#???)
 
 ### Documentation
 

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,22 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+**Dev scripts**
+
+- `scripts/mcp_swap.py` — `use-local` and `revert` accept
+  `--scope {user,project}` so a Claude install can target either the
+  top-level `mcpServers` fallback (every project without an override
+  picks it up) or the per-project `projects.<abs>.mcpServers` entry.
+  Default `project` preserves the previous behaviour. Codex / Cursor /
+  Gemini have no per-project layer; the flag is silently coerced to
+  `user` for them. A single install can hold both scopes
+  simultaneously with independent backups, and `revert --scope user`
+  restores just one layer. State-file schema bumps to v2 (keys are
+  `cli:scope`) with transparent migration of v1 entries on load.
+  (#???)
+
 ### Documentation
 
 - Bump gp-sphinx docs stack to v0.0.1a16 — docs site now renders

--- a/CHANGES
+++ b/CHANGES
@@ -6,9 +6,7 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
-### What's new
-
-**Dev scripts**
+### Development
 
 - `scripts/mcp_swap.py` — `use-local` and `revert` accept
   `--scope {user,project}` so a Claude install can target either the

--- a/CHANGES
+++ b/CHANGES
@@ -24,7 +24,7 @@ _Notes on upcoming releases will be added here_
   `RuntimeError` on a malformed Claude config. The state-file schema
   is internal — no compatibility contract; running an older `mcp_swap`
   against a newer `state.json` is undefined behaviour and not
-  supported. (#???)
+  supported. (#35)
 
 ### Documentation
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,9 +115,9 @@ entries untouched.
   script writes.
 - **Custom binary install locations.** Detection is `shutil.which` plus
   the file existing at the configured global path. Homebrew, npm
-  prefixes (`~/.npm-global/bin`), and post-migration paths
-  (`~/.claude/local/claude`, `~/.gemini/local/gemini`) are picked up
-  only when the binary is already on `PATH`.
+  prefixes (`~/.npm-global/bin`), and the canonical local-install
+  layouts (`~/.claude/local/claude`, `~/.gemini/local/gemini`) are
+  picked up only when the binary is already on `PATH`.
 
 ### Extending to a new CLI
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -81,9 +81,12 @@ the user-level fallback; the project entry stays. `revert` without
   same second don't collide.
 - State is tracked in `~/.local/state/libtmux-mcp-dev/swap/state.json`
   (honours `XDG_STATE_HOME`) so `revert` knows which backup to restore
-  per CLI, including the "added" case where Codex had no libtmux block
-  before. Schema is v2 (keys are `cli:scope`); v1 state files migrate
-  on load.
+  per `(cli, scope)` pair, including the "added" case where Codex had
+  no libtmux block before. Each entry records `swapped_at` (wall-clock
+  timestamp, human-readable for debug) and `seq_no` (monotonic counter,
+  the primary LIFO sort key). Schema is internal — no compatibility
+  contract; running an older `mcp_swap` against a newer `state.json` is
+  undefined.
 - Writes are atomic (tempfile + `os.replace`) and re-validated by
   re-parsing; a bad write is rolled back immediately.
 - `--dry-run` prints a unified diff and writes nothing.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,14 +46,44 @@ This matches Claude's conventional dev form and takes advantage of `uv
 run`'s automatic editable install — source edits flow through on the next
 invocation with no reinstall step.
 
+### `--scope {user,project}` (Claude only)
+
+Claude's `~/.claude.json` has two layers: a top-level `mcpServers`
+fallback that any project without an override picks up, and per-project
+`projects.<abs>.mcpServers` overrides. The flag selects which layer the
+swap writes:
+
+```console
+$ uv run scripts/mcp_swap.py use-local --cli claude --scope project   # default
+$ uv run scripts/mcp_swap.py use-local --cli claude --scope user      # global fallback
+```
+
+`--scope project` (the default) preserves pre-flag behaviour: writes
+under `projects[<repo-abs-path>].mcpServers` and only that one project
+sees the change. `--scope user` flips the top-level fallback so every
+unrelated project directory picks up the local checkout too — useful
+when you're branch-testing across many repos at once.
+
+Codex, Cursor, and Gemini have no per-project layer in their config
+files. The flag is silently coerced to `user` for them, so passing
+`--scope` with a non-Claude `--cli` is harmless.
+
+A single Claude install can hold both scopes simultaneously — separate
+state entries, separate backups. `revert --scope user` restores only
+the user-level fallback; the project entry stays. `revert` without
+`--scope` rolls back every recorded scope for the targeted CLIs.
+
 ### Safety
 
 - Every rewrite writes a timestamped backup (`<config>.bak.mcp-swap-<ts>`)
-  before touching the file.
+  before touching the file. Claude backups also embed the scope
+  (`<config>.bak.mcp-swap-<ts>-{user,project}`) so two scope swaps in the
+  same second don't collide.
 - State is tracked in `~/.local/state/libtmux-mcp-dev/swap/state.json`
   (honours `XDG_STATE_HOME`) so `revert` knows which backup to restore
   per CLI, including the "added" case where Codex had no libtmux block
-  before.
+  before. Schema is v2 (keys are `cli:scope`); v1 state files migrate
+  on load.
 - Writes are atomic (tempfile + `os.replace`) and re-validated by
   re-parsing; a bad write is rolled back immediately.
 - `--dry-run` prints a unified diff and writes nothing.

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -246,6 +246,14 @@ class SwapEntry:
     #: separately via :attr:`seq_no` so this field stays purely
     #: descriptive.
     swapped_at: str
+    #: Monotonic registration counter — the primary LIFO sort key for
+    #: ``cmd_revert``. ``cmd_use_local`` computes the next value as
+    #: ``max(existing seq_nos, default=-1) + 1`` so it strictly
+    #: increases per swap regardless of wall-clock collisions or dict
+    #: iteration order. Same explicit-counter pattern CPython's
+    #: ``Lib/sched.py`` uses to break ties on ``Event(time, priority,
+    #: sequence, …)``.
+    seq_no: int
 
 
 # ---------------------------------------------------------------------------
@@ -815,12 +823,14 @@ def cmd_use_local(args: argparse.Namespace) -> int:
             )
             had_error = 1
             continue
+        next_seq = max((e.seq_no for e in state.values()), default=-1) + 1
         state[(cli, scope)] = SwapEntry(
             config_path=str(info.config_path),
             backup_path=str(backup_path),
             server=server,
             action=action,
             swapped_at=ts,
+            seq_no=next_seq,
         )
         print(f"[{label}] {action}; backup: {backup_path}")
 
@@ -865,26 +875,16 @@ def cmd_revert(args: argparse.Namespace) -> int:
             label = f"{cli}:{args.scope}" if args.scope and cli == "claude" else cli
             print(f"[{label}] no state entry — skip")
             continue
-        # Unwind in reverse-registration order (LIFO) — explicit sort by
-        # ``SwapEntry.swapped_at`` rather than dict iteration order so
-        # the order is independent of JSON parse order or hand-edited
-        # state files. When two scopes back the same physical file
-        # (Claude user + project), the later swap's backup contains the
-        # earlier swap's modifications, so each backup must restore its
-        # own layer *before* the prior one is restored. Same discipline
-        # as ``contextlib.ExitStack``, applied via an explicit timestamp
-        # the way uv's lockfile uses ``.sort_by(id)`` for deterministic
-        # ordering. The original index breaks the tie when two scopes
-        # share the same second so the original-registration LIFO order
-        # is preserved.
-        cli_keys = [
-            k
-            for _, k in sorted(
-                enumerate(cli_keys),
-                key=lambda item: (state[item[1]].swapped_at, item[0]),
-                reverse=True,
-            )
-        ]
+        # Unwind in reverse-registration order (LIFO) — sort by the
+        # explicit ``SwapEntry.seq_no`` counter so order is independent
+        # of JSON parse order, dict iteration, hand-edited state, or
+        # wall-clock collisions. When two scopes back the same physical
+        # file (Claude user + project), the later swap's backup contains
+        # the earlier swap's modifications, so each backup must restore
+        # its own layer before the prior one is restored. Same explicit
+        # counter pattern CPython's ``Lib/sched.py`` uses to break ties
+        # on ``Event(time, priority, sequence, …)``.
+        cli_keys.sort(key=lambda k: state[k].seq_no, reverse=True)
         for key in cli_keys:
             sc_cli, sc_scope = key
             entry = state[key]

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -70,6 +70,54 @@ import tomlkit.items
 CLIName = t.Literal["claude", "codex", "cursor", "gemini"]
 ALL_CLIS: tuple[CLIName, ...] = ("claude", "codex", "cursor", "gemini")
 
+#: Two-layer Claude config: ``"user"`` writes the top-level ``mcpServers``
+#: fallback that applies to every project without its own override; ``"project"``
+#: writes the per-project ``projects.<abs>.mcpServers`` node. Codex / Cursor /
+#: Gemini have no per-project layer in their config files, so for those CLIs
+#: the scope is always normalised to ``"user"`` regardless of what was passed.
+Scope = t.Literal["user", "project"]
+ALL_SCOPES: tuple[Scope, ...] = ("user", "project")
+
+
+def _normalize_scope(cli: CLIName, scope: Scope | None) -> Scope:
+    """Coerce ``scope`` to the value that actually applies to ``cli``.
+
+    Non-Claude CLIs have no per-project config layer — every write to
+    them is necessarily user-level — so the flag is silently coerced to
+    ``"user"`` for those. For Claude, ``None`` defaults to ``"project"``
+    to preserve pre-flag behaviour where the script always wrote the
+    per-project entry.
+    """
+    if cli != "claude":
+        return "user"
+    return scope if scope is not None else "project"
+
+
+def _state_key(cli: CLIName, scope: Scope) -> str:
+    """Compose the ``cli:scope`` key used inside the state file."""
+    return f"{cli}:{scope}"
+
+
+def _parse_state_key(key: str) -> tuple[CLIName, Scope] | None:
+    """Decode a state key, accepting both v2 (``cli:scope``) and v1 (``cli``).
+
+    Legacy v1 keys are migrated in-place: bare ``"claude"`` was the only
+    mode that existed (per-project), so it maps to ``("claude", "project")``;
+    the other CLIs had no scope concept then and are user-level today, so
+    they map to ``("<cli>", "user")``. Returns ``None`` for keys that don't
+    look like either shape so a hand-edited or future-version state file
+    cannot crash ``load_state``.
+    """
+    if ":" in key:
+        cli_str, _, scope_str = key.partition(":")
+        if cli_str in ALL_CLIS and scope_str in ALL_SCOPES:
+            return cli_str, scope_str
+        return None
+    if key in ALL_CLIS:
+        legacy_scope: Scope = "project" if key == "claude" else "user"
+        return key, legacy_scope
+    return None
+
 
 def _xdg_state_home() -> pathlib.Path:
     """Resolve ``$XDG_STATE_HOME`` per the XDG Base Directory spec.
@@ -90,7 +138,11 @@ def _xdg_state_home() -> pathlib.Path:
 # tooling state, distinct from the runtime ``libtmux-mcp`` package.
 STATE_DIR = _xdg_state_home() / "libtmux-mcp-dev" / "swap"
 STATE_FILE = STATE_DIR / "state.json"
-STATE_VERSION = 1
+#: v1 keyed entries by bare ``cli`` name; v2 keys are ``f"{cli}:{scope}"``
+#: so a single Claude install can hold simultaneous user-scope and
+#: project-scope swaps without one clobbering the other's backup. ``load_state``
+#: migrates v1 keys transparently.
+STATE_VERSION = 2
 
 BACKUP_SUFFIX_PREFIX = ".bak.mcp-swap-"
 
@@ -293,14 +345,27 @@ def _claude_project_node(
 
 
 def get_server(
-    cli: CLIName, config: t.Any, name: str, repo: pathlib.Path
+    cli: CLIName,
+    config: t.Any,
+    name: str,
+    repo: pathlib.Path,
+    *,
+    scope: Scope = "project",
 ) -> McpServerSpec | None:
-    """Fetch the MCP server entry for ``name`` from a CLI's config, if present."""
+    """Fetch the MCP server entry for ``name`` from a CLI's config, if present.
+
+    ``scope`` only affects Claude (see :data:`Scope` for the layered shape
+    of ``~/.claude.json``); for Codex / Cursor / Gemini the parameter is
+    accepted-but-ignored because their config has no per-project layer.
+    """
     if cli == "claude":
-        node = _claude_project_node(config, repo, create=False)
-        if not node:
-            return None
-        entry = node.get("mcpServers", {}).get(name)
+        if scope == "user":
+            entry = config.get("mcpServers", {}).get(name)
+        else:
+            node = _claude_project_node(config, repo, create=False)
+            if not node:
+                return None
+            entry = node.get("mcpServers", {}).get(name)
     elif cli in ("cursor", "gemini"):
         entry = config.get("mcpServers", {}).get(name)
     else:  # cli == "codex"
@@ -316,9 +381,23 @@ def set_server(
     name: str,
     spec: McpServerSpec,
     repo: pathlib.Path,
+    *,
+    scope: Scope = "project",
 ) -> t.Literal["replaced", "added"]:
-    """Write ``spec`` under ``name`` in a CLI's config, returning replaced/added."""
+    """Write ``spec`` under ``name`` in a CLI's config, returning replaced/added.
+
+    ``scope == "user"`` for Claude writes the top-level ``mcpServers``
+    fallback used by every project that has no per-project override;
+    ``"project"`` (the default, preserving pre-flag behaviour) writes
+    under ``projects[abs(repo)].mcpServers``. The parameter is silently
+    ignored for non-Claude CLIs.
+    """
     if cli == "claude":
+        if scope == "user":
+            servers = config.setdefault("mcpServers", {})
+            had = name in servers
+            servers[name] = spec.to_json_dict(include_stdio_type=True)
+            return "replaced" if had else "added"
         node = _claude_project_node(config, repo, create=True)
         servers = node.setdefault("mcpServers", {})
         had = name in servers
@@ -350,9 +429,26 @@ def set_server(
     raise AssertionError(msg)
 
 
-def delete_server(cli: CLIName, config: t.Any, name: str, repo: pathlib.Path) -> bool:
-    """Remove the entry for ``name`` from a CLI's config; return whether it existed."""
+def delete_server(
+    cli: CLIName,
+    config: t.Any,
+    name: str,
+    repo: pathlib.Path,
+    *,
+    scope: Scope = "project",
+) -> bool:
+    """Remove the entry for ``name`` from a CLI's config; return whether it existed.
+
+    See :func:`set_server` for the meaning of ``scope`` — the parameter
+    is honoured for Claude and ignored for the other CLIs.
+    """
     if cli == "claude":
+        if scope == "user":
+            servers = config.get("mcpServers", {})
+            if name in servers:
+                del servers[name]
+                return True
+            return False
         node = _claude_project_node(config, repo, create=False)
         if not node:
             return False
@@ -425,34 +521,44 @@ def build_local_spec(repo: pathlib.Path, entry: str) -> McpServerSpec:
 # ---------------------------------------------------------------------------
 
 
-def load_state() -> dict[CLIName, SwapEntry]:
-    """Read the swap-state file, returning an empty mapping when absent."""
+def load_state() -> dict[tuple[CLIName, Scope], SwapEntry]:
+    """Read the swap-state file, returning an empty mapping when absent.
+
+    Transparently migrates v1 state files (bare ``cli`` keys) to the v2
+    ``(cli, scope)`` shape via :func:`_parse_state_key`. Unknown or
+    malformed keys are dropped silently so a hand-edited file or a
+    forward-version file cannot crash the script.
+    """
     if not STATE_FILE.exists():
         return {}
     raw = json.loads(STATE_FILE.read_text())
     entries = raw.get("entries", {})
-    out: dict[CLIName, SwapEntry] = {}
+    out: dict[tuple[CLIName, Scope], SwapEntry] = {}
     for k, v in entries.items():
-        if k in ALL_CLIS:
-            out[t.cast(CLIName, k)] = SwapEntry(**v)
+        parsed = _parse_state_key(k)
+        if parsed is not None:
+            out[parsed] = SwapEntry(**v)
     return out
 
 
-def save_state(entries: dict[CLIName, SwapEntry]) -> None:
+def save_state(entries: dict[tuple[CLIName, Scope], SwapEntry]) -> None:
     """Write the swap-state file atomically (versioned payload)."""
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     payload = {
         "version": STATE_VERSION,
-        "entries": {k: dataclasses.asdict(v) for k, v in entries.items()},
+        "entries": {
+            _state_key(cli, scope): dataclasses.asdict(v)
+            for (cli, scope), v in entries.items()
+        },
     }
     atomic_write(STATE_FILE, (json.dumps(payload, indent=2) + "\n").encode("utf-8"))
 
 
-def clear_state(clis: t.Iterable[CLIName]) -> None:
-    """Remove the given CLIs from the state file; delete the file if empty."""
+def clear_state(keys: t.Iterable[tuple[CLIName, Scope]]) -> None:
+    """Remove the given ``(cli, scope)`` keys; delete the file if empty."""
     current = load_state()
-    for cli in clis:
-        current.pop(cli, None)
+    for key in keys:
+        current.pop(key, None)
     if current:
         save_state(current)
     elif STATE_FILE.exists():
@@ -515,7 +621,14 @@ def cmd_detect(args: argparse.Namespace) -> int:
 
 
 def cmd_status(args: argparse.Namespace) -> int:
-    """Print the current MCP server entry per detected CLI."""
+    """Print the current MCP server entry per detected CLI.
+
+    For Claude, prints separate lines for the user-level fallback
+    (``[claude:user]``) and the per-project override
+    (``[claude:project]``) when both exist; if only one exists, only
+    that line shows. Other CLIs print a single line as ``[<cli>]``
+    since their config has no scope concept.
+    """
     repo = pathlib.Path(args.repo).resolve()
     server = args.server or resolve_repo_meta(repo)[0]
     for cli in args.cli or present_clis():
@@ -524,12 +637,33 @@ def cmd_status(args: argparse.Namespace) -> int:
             print(f"[{cli}] (no config at {info.config_path})")
             continue
         config = load_config(info)
-        spec = get_server(cli, config, server, repo)
-        if spec is None:
-            print(f"[{cli}] no entry for {server!r}")
-            continue
-        tag = _describe_spec(spec, repo)
-        print(f"[{cli}] {server} = {spec.command} {' '.join(spec.args)}  ({tag})")
+        if cli == "claude":
+            user_spec = get_server(cli, config, server, repo, scope="user")
+            project_spec = get_server(cli, config, server, repo, scope="project")
+            shown = False
+            if user_spec is not None:
+                tag = _describe_spec(user_spec, repo)
+                print(
+                    f"[claude:user] {server} = {user_spec.command} "
+                    f"{' '.join(user_spec.args)}  ({tag})"
+                )
+                shown = True
+            if project_spec is not None:
+                tag = _describe_spec(project_spec, repo)
+                print(
+                    f"[claude:project] {server} = {project_spec.command} "
+                    f"{' '.join(project_spec.args)}  ({tag})"
+                )
+                shown = True
+            if not shown:
+                print(f"[claude] no entry for {server!r}")
+        else:
+            spec = get_server(cli, config, server, repo)
+            if spec is None:
+                print(f"[{cli}] no entry for {server!r}")
+                continue
+            tag = _describe_spec(spec, repo)
+            print(f"[{cli}] {server} = {spec.command} {' '.join(spec.args)}  ({tag})")
     return 0
 
 
@@ -547,7 +681,12 @@ def _describe_spec(spec: McpServerSpec, repo: pathlib.Path) -> str:
 
 
 def cmd_use_local(args: argparse.Namespace) -> int:
-    """Rewrite each target CLI's config to run the repo's checkout via ``uv``."""
+    """Rewrite each target CLI's config to run the repo's checkout via ``uv``.
+
+    The optional ``--scope`` flag selects Claude's user-level fallback
+    vs. per-project override; see :data:`Scope`. The flag is silently
+    coerced to ``"user"`` for non-Claude CLIs by :func:`_normalize_scope`.
+    """
     repo = pathlib.Path(args.repo).resolve()
     server, default_entry = resolve_repo_meta(repo)
     server = args.server or server
@@ -563,19 +702,21 @@ def cmd_use_local(args: argparse.Namespace) -> int:
     state = load_state()
     had_error = 0
     for cli in targets:
+        scope = _normalize_scope(cli, args.scope)
+        label = f"{cli}:{scope}" if cli == "claude" else cli
         info = CLIS[cli]
         if not info.config_path.exists():
-            print(f"[{cli}] skip — config not found at {info.config_path}")
+            print(f"[{label}] skip — config not found at {info.config_path}")
             continue
         original_bytes = info.config_path.read_bytes()
         config = load_config(info)
-        current = get_server(cli, config, server, repo)
+        current = get_server(cli, config, server, repo, scope=scope)
         if (
             current
             and current.is_local_uv_directory()
             and current.local_repo_path() == repo
         ):
-            print(f"[{cli}] already local (this repo) — no change")
+            print(f"[{label}] already local (this repo) — no change")
             continue
         # Preserve the existing entry's env on replacement. ``build_local_spec``
         # writes an empty env, so without this merge a swap would silently drop
@@ -583,7 +724,7 @@ def cmd_use_local(args: argparse.Namespace) -> int:
         # knobs). Symmetric with ``_spec_from_entry`` which round-trips env on
         # the read side.
         cli_spec = dataclasses.replace(spec, env={**current.env}) if current else spec
-        action = set_server(cli, config, server, cli_spec, repo)
+        action = set_server(cli, config, server, cli_spec, repo, scope=scope)
         new_bytes = dump_config_bytes(info, config)
 
         if args.dry_run:
@@ -607,18 +748,18 @@ def cmd_use_local(args: argparse.Namespace) -> int:
         except Exception as exc:
             atomic_write(info.config_path, original_bytes)
             print(
-                f"[{cli}] write failed ({exc}); backup at {backup_path}",
+                f"[{label}] write failed ({exc}); backup at {backup_path}",
                 file=sys.stderr,
             )
             had_error = 1
             continue
-        state[cli] = SwapEntry(
+        state[(cli, scope)] = SwapEntry(
             config_path=str(info.config_path),
             backup_path=str(backup_path),
             server=server,
             action=action,
         )
-        print(f"[{cli}] {action}; backup: {backup_path}")
+        print(f"[{label}] {action}; backup: {backup_path}")
 
     if not args.dry_run:
         save_state(state)
@@ -631,30 +772,51 @@ def _revalidate(info: CLIInfo) -> None:
 
 
 def cmd_revert(args: argparse.Namespace) -> int:
-    """Restore each target CLI's config from the backup recorded in the state file."""
+    """Restore each target CLI's config from the backup recorded in the state file.
+
+    Without ``--scope``, every recorded entry for the targeted CLIs is
+    reverted (so a Claude install that has both user-scope and
+    project-scope swaps gets both restored). With ``--scope``, only
+    the matching scope is reverted; the parameter is silently coerced
+    to ``"user"`` for non-Claude CLIs.
+    """
     state = load_state()
-    targets = args.cli or list(state.keys())
+    # No --cli filter: revert every CLI that has any recorded swap.
+    targets = list(args.cli) if args.cli else list({cli for cli, _scope in state})
     if not targets:
         print("no recorded swaps — nothing to revert", file=sys.stderr)
         return 1
 
-    reverted: list[CLIName] = []
+    reverted: list[tuple[CLIName, Scope]] = []
     for cli in targets:
-        entry = state.get(cli)
-        if entry is None:
-            print(f"[{cli}] no state entry — skip")
+        if args.scope is not None:
+            wanted_scopes: tuple[Scope, ...] = (_normalize_scope(cli, args.scope),)
+        else:
+            wanted_scopes = ALL_SCOPES
+        cli_keys = [
+            (sc_cli, sc_scope)
+            for (sc_cli, sc_scope) in state
+            if sc_cli == cli and sc_scope in wanted_scopes
+        ]
+        if not cli_keys:
+            label = f"{cli}:{args.scope}" if args.scope and cli == "claude" else cli
+            print(f"[{label}] no state entry — skip")
             continue
-        backup = pathlib.Path(entry.backup_path)
-        dest = pathlib.Path(entry.config_path)
-        if not backup.exists():
-            print(f"[{cli}] backup missing: {backup}", file=sys.stderr)
-            continue
-        if args.dry_run:
-            print(f"[{cli}] would restore {dest} from {backup}")
-            continue
-        atomic_write(dest, backup.read_bytes())
-        print(f"[{cli}] restored from {backup}")
-        reverted.append(cli)
+        for key in cli_keys:
+            sc_cli, sc_scope = key
+            entry = state[key]
+            label = f"{sc_cli}:{sc_scope}" if sc_cli == "claude" else sc_cli
+            backup = pathlib.Path(entry.backup_path)
+            dest = pathlib.Path(entry.config_path)
+            if not backup.exists():
+                print(f"[{label}] backup missing: {backup}", file=sys.stderr)
+                continue
+            if args.dry_run:
+                print(f"[{label}] would restore {dest} from {backup}")
+                continue
+            atomic_write(dest, backup.read_bytes())
+            print(f"[{label}] restored from {backup}")
+            reverted.append(key)
 
     if not args.dry_run and reverted:
         clear_state(reverted)
@@ -694,11 +856,31 @@ def build_parser() -> argparse.ArgumentParser:
         "--entry", help="uv run entry command (default: [project.scripts] first key)"
     )
     pu.add_argument("--cli", action="append", choices=ALL_CLIS)
+    pu.add_argument(
+        "--scope",
+        choices=ALL_SCOPES,
+        default=None,
+        help=(
+            "Claude config scope: 'user' rewrites the top-level mcpServers "
+            "fallback (every project without an override picks it up), "
+            "'project' rewrites projects.<abs>.mcpServers under this repo. "
+            "Default 'project'. Silently coerced to 'user' for non-Claude CLIs."
+        ),
+    )
     pu.add_argument("--dry-run", action="store_true")
     pu.set_defaults(func=cmd_use_local)
 
     pr = sub.add_parser("revert", help="restore each CLI's config from its swap backup")
     pr.add_argument("--cli", action="append", choices=ALL_CLIS)
+    pr.add_argument(
+        "--scope",
+        choices=ALL_SCOPES,
+        default=None,
+        help=(
+            "Limit revert to one Claude scope. Without this flag, every "
+            "recorded scope for the targeted CLIs is reverted."
+        ),
+    )
     pr.add_argument("--dry-run", action="store_true")
     pr.set_defaults(func=cmd_revert)
 

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -738,8 +738,15 @@ def cmd_use_local(args: argparse.Namespace) -> int:
             sys.stdout.writelines(diff)
             continue
 
+        # Claude is the only CLI where two swaps (different scopes) can
+        # touch the same config file in one second; embed the scope so
+        # the second backup doesn't overwrite the first. Non-Claude
+        # filenames stay byte-compatible with v1 backups.
+        backup_suffix = f"{BACKUP_SUFFIX_PREFIX}{ts}"
+        if cli == "claude":
+            backup_suffix += f"-{scope}"
         backup_path = info.config_path.with_suffix(
-            info.config_path.suffix + f"{BACKUP_SUFFIX_PREFIX}{ts}"
+            info.config_path.suffix + backup_suffix
         )
         backup_path.write_bytes(original_bytes)
         try:

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -39,6 +39,18 @@ This script is best-effort and intentionally narrow:
   walked — workspace files for Cursor/Gemini are silently ignored.
   When workspace precedence matters, run the CLI's own
   ``cursor mcp add ...`` / ``gemini mcp add ...`` directly.
+
+- **Claude scope.** ``use-local`` and ``revert`` accept
+  ``--scope {user,project}``. The default ``project`` writes the
+  per-project entry under ``projects[<abs-repo>].mcpServers`` —
+  only the current repo's directory sees the swap, matching
+  pre-flag behaviour. ``--scope user`` writes Claude's top-level
+  ``mcpServers`` fallback so every project that has no per-project
+  override picks up the swap; useful when QA-ing a branch across
+  many directories. Codex, Cursor, and Gemini have no per-project
+  layer in their config files; the flag is silently coerced to
+  ``user`` for them. Both Claude scopes can coexist with
+  independent backups; full ``revert`` unwinds in LIFO order.
 - **Simple binary detection.** Probing is ``shutil.which(<binary>)``
   plus ``<config_path>.exists()``. Custom install locations
   (Homebrew, npm prefixes, ``~/.npm-global/bin``,

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -877,13 +877,16 @@ def cmd_revert(args: argparse.Namespace) -> int:
             continue
         # Unwind in reverse-registration order (LIFO) — sort by the
         # explicit ``SwapEntry.seq_no`` counter so order is independent
-        # of JSON parse order, dict iteration, hand-edited state, or
-        # wall-clock collisions. When two scopes back the same physical
-        # file (Claude user + project), the later swap's backup contains
-        # the earlier swap's modifications, so each backup must restore
-        # its own layer before the prior one is restored. Same explicit
-        # counter pattern CPython's ``Lib/sched.py`` uses to break ties
-        # on ``Event(time, priority, sequence, …)``.
+        # of JSON parse order, dict iteration, and wall-clock
+        # collisions. ``seq_no`` itself is not validated on load, so a
+        # hand-edited ``state.json`` with corrupted counter values is
+        # outside the guarantees here. When two scopes back the same
+        # physical file (Claude user + project), the later swap's
+        # backup contains the earlier swap's modifications, so each
+        # backup must restore its own layer before the prior one is
+        # restored. Same explicit counter pattern CPython's
+        # ``Lib/sched.py`` uses to break ties on ``Event(time,
+        # priority, sequence, …)``.
         cli_keys.sort(key=lambda k: state[k].seq_no, reverse=True)
         for key in cli_keys:
             sc_cli, sc_scope = key

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -356,6 +356,53 @@ def _claude_project_node(
     return node
 
 
+@t.overload
+def _claude_user_servers(
+    config: dict[str, t.Any], *, create: t.Literal[True]
+) -> dict[str, t.Any]: ...
+
+
+@t.overload
+def _claude_user_servers(
+    config: dict[str, t.Any], *, create: t.Literal[False]
+) -> dict[str, t.Any] | None: ...
+
+
+def _claude_user_servers(
+    config: dict[str, t.Any], *, create: bool
+) -> dict[str, t.Any] | None:
+    """Return (or create) the top-level ``mcpServers`` dict — Claude user scope.
+
+    Mirrors :func:`_claude_project_node` for the user-scope path so the
+    shape guard is centralised once and reused across read / write /
+    delete instead of duplicated at each call site (or worse, missing
+    on read and delete the way the inline write-side guard left them).
+    Same reasoning applies as for the project-scope helper: Claude's
+    config shape is undocumented internal state, so a clear
+    ``RuntimeError`` before the atomic write beats an opaque
+    ``AttributeError`` from ``.setdefault()`` on a non-dict.
+
+    With ``create=True`` the dict is initialised when missing and the
+    return type narrows to ``dict[str, t.Any]``. With ``create=False``
+    a missing key returns ``None``.
+    """
+    raw = config.get("mcpServers")
+    existing: dict[str, t.Any] | None = None
+    if isinstance(raw, dict):
+        existing = raw
+    elif raw is not None:
+        msg = (
+            "Claude config layout appears to have changed; expected "
+            f"'mcpServers' to be a mapping but got "
+            f"{type(raw).__name__}"
+        )
+        raise RuntimeError(msg)
+    if existing is None and create:
+        existing = {}
+        config["mcpServers"] = existing
+    return existing
+
+
 def get_server(
     cli: CLIName,
     config: t.Any,
@@ -372,7 +419,8 @@ def get_server(
     """
     if cli == "claude":
         if scope == "user":
-            entry = config.get("mcpServers", {}).get(name)
+            servers = _claude_user_servers(config, create=False)
+            entry = servers.get(name) if servers else None
         else:
             node = _claude_project_node(config, repo, create=False)
             if not node:
@@ -406,15 +454,7 @@ def set_server(
     """
     if cli == "claude":
         if scope == "user":
-            existing = config.get("mcpServers")
-            if existing is not None and not isinstance(existing, dict):
-                msg = (
-                    "Claude config layout appears to have changed; expected "
-                    f"'mcpServers' to be a mapping but got "
-                    f"{type(existing).__name__}"
-                )
-                raise RuntimeError(msg)
-            servers = config.setdefault("mcpServers", {})
+            servers = _claude_user_servers(config, create=True)
             had = name in servers
             servers[name] = spec.to_json_dict(include_stdio_type=True)
             return "replaced" if had else "added"
@@ -464,8 +504,8 @@ def delete_server(
     """
     if cli == "claude":
         if scope == "user":
-            servers = config.get("mcpServers", {})
-            if name in servers:
+            servers = _claude_user_servers(config, create=False)
+            if servers is not None and name in servers:
                 del servers[name]
                 return True
             return False

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -950,6 +950,14 @@ def cmd_revert(args: argparse.Namespace) -> int:
                 print(f"[{label}] would restore {dest} from {backup}")
                 continue
             atomic_write(dest, backup.read_bytes())
+            # Backup served its purpose; LIFO unwind for this layer is
+            # complete. Delete on success, keep on error — same idiom
+            # CPython's ``tempfile.NamedTemporaryFile`` uses
+            # (Lib/tempfile.py:614-618). If ``atomic_write`` had raised,
+            # this line wouldn't run and the backup would survive for
+            # post-mortem; on success the backup is redundant and would
+            # otherwise accumulate forever across swap/revert cycles.
+            backup.unlink()
             print(f"[{label}] restored from {backup}")
             reverted.append(key)
 

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -809,7 +809,12 @@ def cmd_revert(args: argparse.Namespace) -> int:
             label = f"{cli}:{args.scope}" if args.scope and cli == "claude" else cli
             print(f"[{label}] no state entry — skip")
             continue
-        for key in cli_keys:
+        # Unwind in reverse-registration order (LIFO). When two scopes
+        # back the same physical file (Claude user + project), the
+        # later swap's backup contains the earlier swap's modifications,
+        # so each backup must restore its own layer *before* the prior
+        # one is reapplied. Same discipline as ``contextlib.ExitStack``.
+        for key in reversed(cli_keys):
             sc_cli, sc_scope = key
             entry = state[key]
             label = f"{sc_cli}:{sc_scope}" if sc_cli == "claude" else sc_cli

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -804,7 +804,7 @@ def cmd_use_local(args: argparse.Namespace) -> int:
         # Claude is the only CLI where two swaps (different scopes) can
         # touch the same config file in one second; embed the scope so
         # the second backup doesn't overwrite the first. Non-Claude
-        # filenames stay byte-compatible with v1 backups.
+        # backup filenames carry no scope suffix.
         backup_suffix = f"{BACKUP_SUFFIX_PREFIX}{ts}"
         if cli == "claude":
             backup_suffix += f"-{scope}"

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -394,6 +394,14 @@ def set_server(
     """
     if cli == "claude":
         if scope == "user":
+            existing = config.get("mcpServers")
+            if existing is not None and not isinstance(existing, dict):
+                msg = (
+                    "Claude config layout appears to have changed; expected "
+                    f"'mcpServers' to be a mapping but got "
+                    f"{type(existing).__name__}"
+                )
+                raise RuntimeError(msg)
             servers = config.setdefault("mcpServers", {})
             had = name in servers
             servers[name] = spec.to_json_dict(include_stdio_type=True)

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -717,11 +717,14 @@ def cmd_status(args: argparse.Namespace) -> int:
     For Claude, prints separate lines for the user-level fallback
     (``[claude:user]``) and the per-project override
     (``[claude:project]``) when both exist; if only one exists, only
-    that line shows. Other CLIs print a single line as ``[<cli>]``
-    since their config has no scope concept.
+    that line shows. ``args.scope`` (when set) restricts Claude output
+    to the matching layer only. Other CLIs print a single line as
+    ``[<cli>]`` since their config has no scope concept and ignore
+    ``args.scope``.
     """
     repo = pathlib.Path(args.repo).resolve()
     server = args.server or resolve_repo_meta(repo)[0]
+    scope_filter: Scope | None = args.scope
     for cli in args.cli or present_clis():
         info = CLIS[cli]
         if not info.config_path.exists():
@@ -733,8 +736,19 @@ def cmd_status(args: argparse.Namespace) -> int:
         try:
             config = load_config(info)
             if cli == "claude":
-                user_spec = get_server(cli, config, server, repo, scope="user")
-                project_spec = get_server(cli, config, server, repo, scope="project")
+                # Lazy reads: skip the get_server call entirely for the
+                # filtered-out scope so a malformed projects node doesn't
+                # raise when the user only asked about user scope.
+                user_spec = (
+                    get_server(cli, config, server, repo, scope="user")
+                    if scope_filter in (None, "user")
+                    else None
+                )
+                project_spec = (
+                    get_server(cli, config, server, repo, scope="project")
+                    if scope_filter in (None, "project")
+                    else None
+                )
                 shown = False
                 if user_spec is not None:
                     tag = _describe_spec(user_spec, repo)
@@ -751,7 +765,8 @@ def cmd_status(args: argparse.Namespace) -> int:
                     )
                     shown = True
                 if not shown:
-                    print(f"[claude] no entry for {server!r}")
+                    label = f"claude:{scope_filter}" if scope_filter else "claude"
+                    print(f"[{label}] no entry for {server!r}")
             else:
                 spec = get_server(cli, config, server, repo)
                 if spec is None:
@@ -987,6 +1002,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     ps.add_argument(
         "--cli", action="append", choices=ALL_CLIS, help="limit to one or more CLIs"
+    )
+    ps.add_argument(
+        "--scope",
+        choices=ALL_SCOPES,
+        default=None,
+        help=(
+            "Limit Claude output to one scope: 'user' shows only the "
+            "top-level mcpServers fallback, 'project' shows only the "
+            "projects.<abs>.mcpServers entry. Without this flag, both "
+            "Claude scopes print when both have an entry. No-op for "
+            "non-Claude CLIs (their config has no per-project layer)."
+        ),
     )
     ps.set_defaults(func=cmd_status)
 

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -70,6 +70,7 @@ import difflib
 import json
 import os
 import pathlib
+import re
 import shutil
 import sys
 import tempfile
@@ -150,13 +151,41 @@ def _xdg_state_home() -> pathlib.Path:
 # tooling state, distinct from the runtime ``libtmux-mcp`` package.
 STATE_DIR = _xdg_state_home() / "libtmux-mcp-dev" / "swap"
 STATE_FILE = STATE_DIR / "state.json"
-#: v1 keyed entries by bare ``cli`` name; v2 keys are ``f"{cli}:{scope}"``
-#: so a single Claude install can hold simultaneous user-scope and
-#: project-scope swaps without one clobbering the other's backup. ``load_state``
-#: migrates v1 keys transparently.
-STATE_VERSION = 2
+#: v1 keyed entries by bare ``cli`` name; v2 added scope-suffixed keys
+#: ``f"{cli}:{scope}"`` so a single Claude install could hold simultaneous
+#: user-scope and project-scope swaps; v3 added the explicit ``swapped_at``
+#: timestamp on :class:`SwapEntry` so ``cmd_revert`` can sort by registration
+#: order instead of relying on dict iteration order through the JSON
+#: round-trip. ``load_state`` migrates v1 → v3 transparently (v2 entries
+#: synthesise ``swapped_at`` from the timestamp embedded in
+#: ``backup_path``; v1 entries do the same after the bare-key migration).
+STATE_VERSION = 3
 
 BACKUP_SUFFIX_PREFIX = ".bak.mcp-swap-"
+
+#: Match the ``YYYYMMDDHHMMSS`` timestamp embedded in a backup filename
+#: produced by ``cmd_use_local``. Used to synthesise
+#: :attr:`SwapEntry.swapped_at` when migrating legacy state files that
+#: predate the explicit field.
+_BACKUP_TS_RE = re.compile(re.escape(BACKUP_SUFFIX_PREFIX) + r"(\d{14})")
+
+
+def _swapped_at_from_backup(backup_path: str) -> str:
+    """Extract the ``YYYYMMDDHHMMSS`` timestamp from a backup filename.
+
+    Backup files are named ``<config>.bak.mcp-swap-<ts>`` (and Claude
+    backups since v2 also append ``-{user,project}`` for collision
+    avoidance). The timestamp is the registration moment of the swap, so
+    it doubles as the value of :attr:`SwapEntry.swapped_at` when
+    migrating legacy state files that lack the explicit field.
+
+    Returns ``""`` when the filename doesn't match the expected pattern
+    (e.g. someone hand-edited the state file to point at an unrelated
+    backup) so the caller can fall back gracefully without crashing on
+    revert.
+    """
+    match = _BACKUP_TS_RE.search(backup_path)
+    return match.group(1) if match else ""
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +280,15 @@ class SwapEntry:
     backup_path: str
     server: str
     action: t.Literal["replaced", "added"]
+    #: ``YYYYMMDDHHMMSS`` registration timestamp, sortable lexically. Empty
+    #: string for v2 legacy entries that didn't track this; ``load_state``
+    #: synthesises a value from ``backup_path`` (which already encodes the
+    #: timestamp) so revert can sort by registration order without relying
+    #: on dict-iteration order through the JSON round-trip. Adding this
+    #: field follows the precedent set by CPython's ``contextlib.ExitStack``
+    #: (explicit deque ordering) and uv's lockfile (explicit ``.sort_by``)
+    #: rather than the implicit-iteration approach.
+    swapped_at: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -585,9 +623,11 @@ def load_state() -> dict[tuple[CLIName, Scope], SwapEntry]:
     """Read the swap-state file, returning an empty mapping when absent.
 
     Transparently migrates v1 state files (bare ``cli`` keys) to the v2
-    ``(cli, scope)`` shape via :func:`_parse_state_key`. Unknown or
-    malformed keys are dropped silently so a hand-edited file or a
-    forward-version file cannot crash the script.
+    ``(cli, scope)`` shape via :func:`_parse_state_key`, and v2 entries
+    that lack ``swapped_at`` to v3 by parsing the timestamp from
+    :attr:`SwapEntry.backup_path`. Unknown or malformed keys are dropped
+    silently so a hand-edited file or a forward-version file cannot
+    crash the script.
     """
     if not STATE_FILE.exists():
         return {}
@@ -596,8 +636,22 @@ def load_state() -> dict[tuple[CLIName, Scope], SwapEntry]:
     out: dict[tuple[CLIName, Scope], SwapEntry] = {}
     for k, v in entries.items():
         parsed = _parse_state_key(k)
-        if parsed is not None:
-            out[parsed] = SwapEntry(**v)
+        if parsed is None:
+            continue
+        # Only the fields SwapEntry knows about — drop unknown keys
+        # so a forward-version state file with extra metadata still
+        # loads. v2 entries lack ``swapped_at``; the dataclass default
+        # fills in ``""`` and the migration below populates it from
+        # ``backup_path``.
+        kwargs = {
+            f.name: v[f.name] for f in dataclasses.fields(SwapEntry) if f.name in v
+        }
+        entry = SwapEntry(**kwargs)
+        if not entry.swapped_at:
+            entry = dataclasses.replace(
+                entry, swapped_at=_swapped_at_from_backup(entry.backup_path)
+            )
+        out[parsed] = entry
     return out
 
 
@@ -825,6 +879,7 @@ def cmd_use_local(args: argparse.Namespace) -> int:
             backup_path=str(backup_path),
             server=server,
             action=action,
+            swapped_at=ts,
         )
         print(f"[{label}] {action}; backup: {backup_path}")
 
@@ -869,12 +924,27 @@ def cmd_revert(args: argparse.Namespace) -> int:
             label = f"{cli}:{args.scope}" if args.scope and cli == "claude" else cli
             print(f"[{label}] no state entry — skip")
             continue
-        # Unwind in reverse-registration order (LIFO). When two scopes
-        # back the same physical file (Claude user + project), the
-        # later swap's backup contains the earlier swap's modifications,
-        # so each backup must restore its own layer *before* the prior
-        # one is reapplied. Same discipline as ``contextlib.ExitStack``.
-        for key in reversed(cli_keys):
+        # Unwind in reverse-registration order (LIFO) — explicit sort by
+        # ``SwapEntry.swapped_at`` rather than dict iteration order so
+        # the order is independent of JSON parse order or hand-edited
+        # state files. When two scopes back the same physical file
+        # (Claude user + project), the later swap's backup contains the
+        # earlier swap's modifications, so each backup must restore its
+        # own layer *before* the prior one is restored. Same discipline
+        # as ``contextlib.ExitStack``, applied via an explicit timestamp
+        # the way uv's lockfile uses ``.sort_by(id)`` for deterministic
+        # ordering. The original index breaks the tie when two scopes
+        # share the same second so the original-registration LIFO order
+        # is preserved.
+        cli_keys = [
+            k
+            for _, k in sorted(
+                enumerate(cli_keys),
+                key=lambda item: (state[item[1]].swapped_at, item[0]),
+                reverse=True,
+            )
+        ]
+        for key in cli_keys:
             sc_cli, sc_scope = key
             entry = state[key]
             label = f"{sc_cli}:{sc_scope}" if sc_cli == "claude" else sc_cli

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -70,7 +70,6 @@ import difflib
 import json
 import os
 import pathlib
-import re
 import shutil
 import sys
 import tempfile
@@ -112,23 +111,18 @@ def _state_key(cli: CLIName, scope: Scope) -> str:
 
 
 def _parse_state_key(key: str) -> tuple[CLIName, Scope] | None:
-    """Decode a state key, accepting both v2 (``cli:scope``) and v1 (``cli``).
+    """Decode a ``cli:scope`` state key, returning ``None`` for malformed input.
 
-    Legacy v1 keys are migrated in-place: bare ``"claude"`` was the only
-    mode that existed (per-project), so it maps to ``("claude", "project")``;
-    the other CLIs had no scope concept then and are user-level today, so
-    they map to ``("<cli>", "user")``. Returns ``None`` for keys that don't
-    look like either shape so a hand-edited or future-version state file
-    cannot crash ``load_state``.
+    The script declares no compatibility contract for its state file —
+    schema is internal — so this only accepts the canonical
+    ``f"{cli}:{scope}"`` form. Hand-edited or unrecognised keys return
+    ``None`` so ``load_state`` can drop them without crashing.
     """
-    if ":" in key:
-        cli_str, _, scope_str = key.partition(":")
-        if cli_str in ALL_CLIS and scope_str in ALL_SCOPES:
-            return cli_str, scope_str
+    if ":" not in key:
         return None
-    if key in ALL_CLIS:
-        legacy_scope: Scope = "project" if key == "claude" else "user"
-        return key, legacy_scope
+    cli_str, _, scope_str = key.partition(":")
+    if cli_str in ALL_CLIS and scope_str in ALL_SCOPES:
+        return cli_str, scope_str
     return None
 
 
@@ -151,41 +145,8 @@ def _xdg_state_home() -> pathlib.Path:
 # tooling state, distinct from the runtime ``libtmux-mcp`` package.
 STATE_DIR = _xdg_state_home() / "libtmux-mcp-dev" / "swap"
 STATE_FILE = STATE_DIR / "state.json"
-#: v1 keyed entries by bare ``cli`` name; v2 added scope-suffixed keys
-#: ``f"{cli}:{scope}"`` so a single Claude install could hold simultaneous
-#: user-scope and project-scope swaps; v3 added the explicit ``swapped_at``
-#: timestamp on :class:`SwapEntry` so ``cmd_revert`` can sort by registration
-#: order instead of relying on dict iteration order through the JSON
-#: round-trip. ``load_state`` migrates v1 → v3 transparently (v2 entries
-#: synthesise ``swapped_at`` from the timestamp embedded in
-#: ``backup_path``; v1 entries do the same after the bare-key migration).
-STATE_VERSION = 3
 
 BACKUP_SUFFIX_PREFIX = ".bak.mcp-swap-"
-
-#: Match the ``YYYYMMDDHHMMSS`` timestamp embedded in a backup filename
-#: produced by ``cmd_use_local``. Used to synthesise
-#: :attr:`SwapEntry.swapped_at` when migrating legacy state files that
-#: predate the explicit field.
-_BACKUP_TS_RE = re.compile(re.escape(BACKUP_SUFFIX_PREFIX) + r"(\d{14})")
-
-
-def _swapped_at_from_backup(backup_path: str) -> str:
-    """Extract the ``YYYYMMDDHHMMSS`` timestamp from a backup filename.
-
-    Backup files are named ``<config>.bak.mcp-swap-<ts>`` (and Claude
-    backups since v2 also append ``-{user,project}`` for collision
-    avoidance). The timestamp is the registration moment of the swap, so
-    it doubles as the value of :attr:`SwapEntry.swapped_at` when
-    migrating legacy state files that lack the explicit field.
-
-    Returns ``""`` when the filename doesn't match the expected pattern
-    (e.g. someone hand-edited the state file to point at an unrelated
-    backup) so the caller can fall back gracefully without crashing on
-    revert.
-    """
-    match = _BACKUP_TS_RE.search(backup_path)
-    return match.group(1) if match else ""
 
 
 # ---------------------------------------------------------------------------
@@ -280,15 +241,11 @@ class SwapEntry:
     backup_path: str
     server: str
     action: t.Literal["replaced", "added"]
-    #: ``YYYYMMDDHHMMSS`` registration timestamp, sortable lexically. Empty
-    #: string for v2 legacy entries that didn't track this; ``load_state``
-    #: synthesises a value from ``backup_path`` (which already encodes the
-    #: timestamp) so revert can sort by registration order without relying
-    #: on dict-iteration order through the JSON round-trip. Adding this
-    #: field follows the precedent set by CPython's ``contextlib.ExitStack``
-    #: (explicit deque ordering) and uv's lockfile (explicit ``.sort_by``)
-    #: rather than the implicit-iteration approach.
-    swapped_at: str = ""
+    #: ``YYYYMMDDHHMMSS`` registration timestamp, human-readable for
+    #: anyone inspecting ``state.json`` directly. Sort order is enforced
+    #: separately via :attr:`seq_no` so this field stays purely
+    #: descriptive.
+    swapped_at: str
 
 
 # ---------------------------------------------------------------------------
@@ -622,12 +579,10 @@ def build_local_spec(repo: pathlib.Path, entry: str) -> McpServerSpec:
 def load_state() -> dict[tuple[CLIName, Scope], SwapEntry]:
     """Read the swap-state file, returning an empty mapping when absent.
 
-    Transparently migrates v1 state files (bare ``cli`` keys) to the v2
-    ``(cli, scope)`` shape via :func:`_parse_state_key`, and v2 entries
-    that lack ``swapped_at`` to v3 by parsing the timestamp from
-    :attr:`SwapEntry.backup_path`. Unknown or malformed keys are dropped
-    silently so a hand-edited file or a forward-version file cannot
-    crash the script.
+    The state file's schema is internal — no compatibility contract —
+    so this loader assumes a single canonical shape. Malformed keys
+    (those that don't parse as ``cli:scope``) are dropped silently so
+    a hand-edited file cannot crash the script.
     """
     if not STATE_FILE.exists():
         return {}
@@ -638,28 +593,14 @@ def load_state() -> dict[tuple[CLIName, Scope], SwapEntry]:
         parsed = _parse_state_key(k)
         if parsed is None:
             continue
-        # Only the fields SwapEntry knows about — drop unknown keys
-        # so a forward-version state file with extra metadata still
-        # loads. v2 entries lack ``swapped_at``; the dataclass default
-        # fills in ``""`` and the migration below populates it from
-        # ``backup_path``.
-        kwargs = {
-            f.name: v[f.name] for f in dataclasses.fields(SwapEntry) if f.name in v
-        }
-        entry = SwapEntry(**kwargs)
-        if not entry.swapped_at:
-            entry = dataclasses.replace(
-                entry, swapped_at=_swapped_at_from_backup(entry.backup_path)
-            )
-        out[parsed] = entry
+        out[parsed] = SwapEntry(**v)
     return out
 
 
 def save_state(entries: dict[tuple[CLIName, Scope], SwapEntry]) -> None:
-    """Write the swap-state file atomically (versioned payload)."""
+    """Write the swap-state file atomically."""
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     payload = {
-        "version": STATE_VERSION,
         "entries": {
             _state_key(cli, scope): dataclasses.asdict(v)
             for (cli, scope), v in entries.items()

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -808,7 +808,7 @@ def cmd_revert(args: argparse.Namespace) -> int:
     to ``"user"`` for non-Claude CLIs.
     """
     state = load_state()
-    # No --cli filter: revert every CLI that has any recorded swap.
+    # Without --cli, revert every CLI that has any recorded swap.
     targets = list(args.cli) if args.cli else list({cli for cli, _scope in state})
     if not targets:
         print("no recorded swaps — nothing to revert", file=sys.stderr)

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -699,34 +699,43 @@ def cmd_status(args: argparse.Namespace) -> int:
         if not info.config_path.exists():
             print(f"[{cli}] (no config at {info.config_path})")
             continue
-        config = load_config(info)
-        if cli == "claude":
-            user_spec = get_server(cli, config, server, repo, scope="user")
-            project_spec = get_server(cli, config, server, repo, scope="project")
-            shown = False
-            if user_spec is not None:
-                tag = _describe_spec(user_spec, repo)
+        # Wrap the read + shape-guarded queries in try/except RuntimeError
+        # so a malformed Claude config surfaces as a clean per-CLI error
+        # instead of aborting status output for the rest of the CLIs.
+        try:
+            config = load_config(info)
+            if cli == "claude":
+                user_spec = get_server(cli, config, server, repo, scope="user")
+                project_spec = get_server(cli, config, server, repo, scope="project")
+                shown = False
+                if user_spec is not None:
+                    tag = _describe_spec(user_spec, repo)
+                    print(
+                        f"[claude:user] {server} = {user_spec.command} "
+                        f"{' '.join(user_spec.args)}  ({tag})"
+                    )
+                    shown = True
+                if project_spec is not None:
+                    tag = _describe_spec(project_spec, repo)
+                    print(
+                        f"[claude:project] {server} = {project_spec.command} "
+                        f"{' '.join(project_spec.args)}  ({tag})"
+                    )
+                    shown = True
+                if not shown:
+                    print(f"[claude] no entry for {server!r}")
+            else:
+                spec = get_server(cli, config, server, repo)
+                if spec is None:
+                    print(f"[{cli}] no entry for {server!r}")
+                    continue
+                tag = _describe_spec(spec, repo)
                 print(
-                    f"[claude:user] {server} = {user_spec.command} "
-                    f"{' '.join(user_spec.args)}  ({tag})"
+                    f"[{cli}] {server} = {spec.command} {' '.join(spec.args)}  ({tag})"
                 )
-                shown = True
-            if project_spec is not None:
-                tag = _describe_spec(project_spec, repo)
-                print(
-                    f"[claude:project] {server} = {project_spec.command} "
-                    f"{' '.join(project_spec.args)}  ({tag})"
-                )
-                shown = True
-            if not shown:
-                print(f"[claude] no entry for {server!r}")
-        else:
-            spec = get_server(cli, config, server, repo)
-            if spec is None:
-                print(f"[{cli}] no entry for {server!r}")
-                continue
-            tag = _describe_spec(spec, repo)
-            print(f"[{cli}] {server} = {spec.command} {' '.join(spec.args)}  ({tag})")
+        except RuntimeError as exc:
+            print(f"[{cli}] {exc}", file=sys.stderr)
+            continue
     return 0
 
 
@@ -771,24 +780,36 @@ def cmd_use_local(args: argparse.Namespace) -> int:
         if not info.config_path.exists():
             print(f"[{label}] skip — config not found at {info.config_path}")
             continue
-        original_bytes = info.config_path.read_bytes()
-        config = load_config(info)
-        current = get_server(cli, config, server, repo, scope=scope)
-        if (
-            current
-            and current.is_local_uv_directory()
-            and current.local_repo_path() == repo
-        ):
-            print(f"[{label}] already local (this repo) — no change")
+        # Wrap the read + shape-guarded mutation in try/except RuntimeError
+        # so a malformed Claude config (top-level mcpServers / projects not a
+        # mapping) surfaces as a clean per-CLI error instead of an uncaught
+        # traceback. Same per-CLI continuation pattern the inner write-failure
+        # handler below uses.
+        try:
+            original_bytes = info.config_path.read_bytes()
+            config = load_config(info)
+            current = get_server(cli, config, server, repo, scope=scope)
+            if (
+                current
+                and current.is_local_uv_directory()
+                and current.local_repo_path() == repo
+            ):
+                print(f"[{label}] already local (this repo) — no change")
+                continue
+            # Preserve the existing entry's env on replacement. ``build_local_spec``
+            # writes an empty env, so without this merge a swap would silently drop
+            # client-side settings (LIBTMUX_SAFETY, LIBTMUX_SOCKET, custom dev
+            # knobs). Symmetric with ``_spec_from_entry`` which round-trips env on
+            # the read side.
+            cli_spec = (
+                dataclasses.replace(spec, env={**current.env}) if current else spec
+            )
+            action = set_server(cli, config, server, cli_spec, repo, scope=scope)
+            new_bytes = dump_config_bytes(info, config)
+        except RuntimeError as exc:
+            print(f"[{label}] {exc}", file=sys.stderr)
+            had_error = 1
             continue
-        # Preserve the existing entry's env on replacement. ``build_local_spec``
-        # writes an empty env, so without this merge a swap would silently drop
-        # client-side settings (LIBTMUX_SAFETY, LIBTMUX_SOCKET, custom dev
-        # knobs). Symmetric with ``_spec_from_entry`` which round-trips env on
-        # the read side.
-        cli_spec = dataclasses.replace(spec, env={**current.env}) if current else spec
-        action = set_server(cli, config, server, cli_spec, repo, scope=scope)
-        new_bytes = dump_config_bytes(info, config)
 
         if args.dry_run:
             print(f"--- {info.config_path} (current)")

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -126,6 +126,30 @@ def _parse_state_key(key: str) -> tuple[CLIName, Scope] | None:
     return None
 
 
+def _parse_state_entry(v: dict[str, t.Any]) -> SwapEntry | None:
+    """Build a :class:`SwapEntry` from a raw state-file dict, or ``None``.
+
+    Validates at the trust boundary so a hand-edited ``state.json`` can't
+    crash later code paths — particularly :func:`cmd_revert`'s LIFO sort,
+    which compares ``SwapEntry.seq_no`` and would raise ``TypeError`` on a
+    mixed ``int``/``str`` ordering. ``seq_no`` is coerced via ``int()``;
+    any ``KeyError`` (missing required field), ``ValueError`` (non-numeric
+    string), or ``TypeError`` (wrong shape, extra keys for the dataclass)
+    drops the entry silently. Same drop-on-malformed posture as
+    :func:`_parse_state_key`.
+
+    Mirrors CPython's ``Lib/sched.py`` discipline: validate at the
+    counter's *origin* (``enterabs`` for sched, ``load_state`` here), not
+    at sort time. State-file schema is internal — no compatibility
+    contract — so silent drop is the right failure mode.
+    """
+    try:
+        v = {**v, "seq_no": int(v["seq_no"])}
+        return SwapEntry(**v)
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
 def _xdg_state_home() -> pathlib.Path:
     """Resolve ``$XDG_STATE_HOME`` per the XDG Base Directory spec.
 
@@ -589,8 +613,9 @@ def load_state() -> dict[tuple[CLIName, Scope], SwapEntry]:
 
     The state file's schema is internal — no compatibility contract —
     so this loader assumes a single canonical shape. Malformed keys
-    (those that don't parse as ``cli:scope``) are dropped silently so
-    a hand-edited file cannot crash the script.
+    (those that don't parse as ``cli:scope``) and entries with a
+    non-coercible ``seq_no`` or missing required fields are dropped
+    silently so a hand-edited file cannot crash the script.
     """
     if not STATE_FILE.exists():
         return {}
@@ -601,7 +626,10 @@ def load_state() -> dict[tuple[CLIName, Scope], SwapEntry]:
         parsed = _parse_state_key(k)
         if parsed is None:
             continue
-        out[parsed] = SwapEntry(**v)
+        entry = _parse_state_entry(v)
+        if entry is None:
+            continue
+        out[parsed] = entry
     return out
 
 
@@ -899,15 +927,15 @@ def cmd_revert(args: argparse.Namespace) -> int:
         # Unwind in reverse-registration order (LIFO) — sort by the
         # explicit ``SwapEntry.seq_no`` counter so order is independent
         # of JSON parse order, dict iteration, and wall-clock
-        # collisions. ``seq_no`` itself is not validated on load, so a
-        # hand-edited ``state.json`` with corrupted counter values is
-        # outside the guarantees here. When two scopes back the same
-        # physical file (Claude user + project), the later swap's
-        # backup contains the earlier swap's modifications, so each
-        # backup must restore its own layer before the prior one is
-        # restored. Same explicit counter pattern CPython's
-        # ``Lib/sched.py`` uses to break ties on ``Event(time,
-        # priority, sequence, …)``.
+        # collisions. ``seq_no`` is coerced to ``int`` at load time by
+        # ``_parse_state_entry``; entries with a non-coercible value
+        # are dropped before they reach this sort, so the comparison
+        # is always int vs int. When two scopes back the same physical
+        # file (Claude user + project), the later swap's backup
+        # contains the earlier swap's modifications, so each backup
+        # must restore its own layer before the prior one is restored.
+        # Same explicit counter pattern CPython's ``Lib/sched.py`` uses
+        # to break ties on ``Event(time, priority, sequence, …)``.
         cli_keys.sort(key=lambda k: state[k].seq_no, reverse=True)
         for key in cli_keys:
             sc_cli, sc_scope = key

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -520,35 +520,6 @@ def test_use_local_populates_swapped_at(
     assert entry.swapped_at in entry.backup_path
 
 
-def test_legacy_v2_state_migrates_swapped_at_from_backup_path(
-    fake_home: pathlib.Path,
-) -> None:
-    """A v2 state entry without ``swapped_at`` gets one synthesised from backup_path.
-
-    The backup filename always encodes the registration timestamp as
-    ``mcp-swap-<YYYYMMDDHHMMSS>[-scope]``, so legacy v2 entries (which
-    didn't carry an explicit ``swapped_at`` field) recover their
-    timestamp on load and participate in LIFO ordering normally.
-    """
-    mcp_swap.STATE_DIR.mkdir(parents=True, exist_ok=True)
-    legacy = {
-        "version": 2,
-        "entries": {
-            "claude:user": {
-                "config_path": "/tmp/.claude.json",
-                "backup_path": "/tmp/.claude.json.bak.mcp-swap-20240115093030-user",
-                "server": "libtmux",
-                "action": "replaced",
-                # NB: no swapped_at field — this is the legacy shape.
-            },
-        },
-    }
-    mcp_swap.STATE_FILE.write_text(json.dumps(legacy))
-
-    state = mcp_swap.load_state()
-    assert state[("claude", "user")].swapped_at == "20240115093030"
-
-
 def test_lifo_revert_orders_by_swapped_at_not_dict_iteration(
     fake_home: pathlib.Path,
 ) -> None:
@@ -604,41 +575,6 @@ def test_lifo_revert_orders_by_swapped_at_not_dict_iteration(
     # LIFO order: newer (claude:user) restored first, then older
     # (claude:project). Final file contents = older backup = "ORIGINAL".
     assert info.config_path.read_text() == "ORIGINAL\n"
-
-
-def test_legacy_v1_state_migrates_to_v2_keys(
-    fake_home: pathlib.Path, fake_repo: pathlib.Path
-) -> None:
-    """A v1 state file with bare ``cli`` keys is migrated on load.
-
-    ``claude`` (legacy default was per-project) → ``("claude", "project")``.
-    Bare ``codex`` / ``cursor`` / ``gemini`` (no per-project layer) →
-    ``("<cli>", "user")``.
-    """
-    mcp_swap.STATE_DIR.mkdir(parents=True, exist_ok=True)
-    legacy = {
-        "version": 1,
-        "entries": {
-            "claude": {
-                "config_path": "/tmp/.claude.json",
-                "backup_path": "/tmp/.claude.json.bak",
-                "server": "libtmux",
-                "action": "replaced",
-            },
-            "codex": {
-                "config_path": "/tmp/codex.toml",
-                "backup_path": "/tmp/codex.toml.bak",
-                "server": "libtmux",
-                "action": "added",
-            },
-        },
-    }
-    mcp_swap.STATE_FILE.write_text(json.dumps(legacy))
-
-    state = mcp_swap.load_state()
-    assert set(state.keys()) == {("claude", "project"), ("codex", "user")}
-    assert state[("claude", "project")].backup_path == "/tmp/.claude.json.bak"
-    assert state[("codex", "user")].action == "added"
 
 
 def test_non_claude_scope_user_passes_through_to_global_config(
@@ -800,6 +736,7 @@ def test_save_state_writes_atomically(fake_home: pathlib.Path) -> None:
         backup_path="/tmp/cfg.json.bak",
         server="libtmux",
         action="replaced",
+        swapped_at="20260101000000",
     )
     mcp_swap.save_state({("claude", "project"): entry})
 

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -785,3 +785,33 @@ def test_claude_user_scope_rejects_non_mapping_mcpServers(
     spec = mcp_swap.McpServerSpec(command="uv", args=["run", "libtmux-mcp"])
     with pytest.raises(RuntimeError, match="layout appears to have changed"):
         mcp_swap.set_server("claude", config, "libtmux", spec, fake_repo, scope="user")
+
+
+def test_claude_user_scope_get_server_rejects_non_mapping_mcpServers(
+    fake_repo: pathlib.Path,
+) -> None:
+    """User-scope ``get_server`` rejects a non-mapping top-level ``mcpServers``.
+
+    Mirrors the write-side guard so reads fail loudly with an actionable
+    ``RuntimeError`` instead of an opaque ``AttributeError`` from a
+    chained ``.get()``. Symmetric coverage matches the project-scope
+    path, which routes all three of read/write/delete through
+    ``_claude_project_node``.
+    """
+    config: dict[str, t.Any] = {"mcpServers": "not a dict"}
+    with pytest.raises(RuntimeError, match="layout appears to have changed"):
+        mcp_swap.get_server("claude", config, "libtmux", fake_repo, scope="user")
+
+
+def test_claude_user_scope_delete_server_rejects_non_mapping_mcpServers(
+    fake_repo: pathlib.Path,
+) -> None:
+    """User-scope ``delete_server`` rejects a non-mapping top-level ``mcpServers``.
+
+    Mirrors the write- and read-side guards so deletes fail loudly with
+    an actionable ``RuntimeError`` instead of a silent no-op or a
+    ``TypeError`` from ``name in servers`` against a non-mapping.
+    """
+    config: dict[str, t.Any] = {"mcpServers": "not a dict"}
+    with pytest.raises(RuntimeError, match="layout appears to have changed"):
+        mcp_swap.delete_server("claude", config, "libtmux", fake_repo, scope="user")

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -767,3 +767,21 @@ def test_claude_project_node_accepts_well_shaped_config(
     node = mcp_swap._claude_project_node(config, fake_repo, create=True)
     assert isinstance(node, dict)
     assert "mcpServers" in node
+
+
+def test_claude_user_scope_rejects_non_mapping_mcpServers(
+    fake_repo: pathlib.Path,
+) -> None:
+    """User-scope ``set_server`` rejects a non-mapping top-level ``mcpServers``.
+
+    Symmetric with the existing ``_claude_project_node`` shape guard for
+    the per-project path. Without this guard, a malformed Claude config
+    would surface as an opaque ``AttributeError`` from ``.setdefault()``;
+    with it, the user gets the same actionable RuntimeError that the
+    project-scope path raises. Pattern follows hatchling's pre-mutation
+    config validation in ``builders/config.py``.
+    """
+    config: dict[str, t.Any] = {"mcpServers": "not a dict"}
+    spec = mcp_swap.McpServerSpec(command="uv", args=["run", "libtmux-mcp"])
+    with pytest.raises(RuntimeError, match="layout appears to have changed"):
+        mcp_swap.set_server("claude", config, "libtmux", spec, fake_repo, scope="user")

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -499,6 +499,113 @@ def test_claude_full_revert_unwinds_both_scopes_in_lifo_order(
     assert not mcp_swap.STATE_FILE.exists()
 
 
+def test_use_local_populates_swapped_at(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """``cmd_use_local`` records the registration timestamp on each entry."""
+    info = mcp_swap.CLIS["cursor"]
+    _write_json(info.config_path, {"mcpServers": {"libtmux": _pinned_json_entry()}})
+
+    args = mcp_swap.build_parser().parse_args(
+        ["use-local", "--repo", str(fake_repo), "--cli", "cursor"]
+    )
+    assert mcp_swap.cmd_use_local(args) == 0
+
+    state = mcp_swap.load_state()
+    entry = state[("cursor", "user")]
+    # ``swapped_at`` is the same ``time.strftime("%Y%m%d%H%M%S")`` value
+    # that goes into the backup filename, so checking format suffices.
+    assert len(entry.swapped_at) == 14 and entry.swapped_at.isdigit()
+    # And the backup filename embeds the same timestamp.
+    assert entry.swapped_at in entry.backup_path
+
+
+def test_legacy_v2_state_migrates_swapped_at_from_backup_path(
+    fake_home: pathlib.Path,
+) -> None:
+    """A v2 state entry without ``swapped_at`` gets one synthesised from backup_path.
+
+    The backup filename always encodes the registration timestamp as
+    ``mcp-swap-<YYYYMMDDHHMMSS>[-scope]``, so legacy v2 entries (which
+    didn't carry an explicit ``swapped_at`` field) recover their
+    timestamp on load and participate in LIFO ordering normally.
+    """
+    mcp_swap.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "version": 2,
+        "entries": {
+            "claude:user": {
+                "config_path": "/tmp/.claude.json",
+                "backup_path": "/tmp/.claude.json.bak.mcp-swap-20240115093030-user",
+                "server": "libtmux",
+                "action": "replaced",
+                # NB: no swapped_at field — this is the legacy shape.
+            },
+        },
+    }
+    mcp_swap.STATE_FILE.write_text(json.dumps(legacy))
+
+    state = mcp_swap.load_state()
+    assert state[("claude", "user")].swapped_at == "20240115093030"
+
+
+def test_lifo_revert_orders_by_swapped_at_not_dict_iteration(
+    fake_home: pathlib.Path,
+) -> None:
+    """LIFO revert sorts by ``swapped_at`` regardless of state-file dict order.
+
+    Regression test for the pre-explicit-timestamp implementation:
+    ``reversed(cli_keys)`` worked only because dict insertion order
+    happened to match registration order. This test seeds a state file
+    with entries in a *deliberately wrong* dict order — newest first,
+    oldest second — and asserts the revert still applies the newest
+    backup first (true LIFO). With the old `reversed()` approach this
+    would apply the older backup first and leave the file partially
+    rolled back; with the explicit ``swapped_at`` sort it restores
+    correctly regardless of dict order.
+    """
+    info = mcp_swap.CLIS["claude"]
+    info.config_path.write_text("AFTER_BOTH_SWAPS\n")
+
+    backup_old = mcp_swap.STATE_DIR.parent / "old-backup"
+    backup_new = mcp_swap.STATE_DIR.parent / "new-backup"
+    backup_old.parent.mkdir(parents=True, exist_ok=True)
+    backup_old.write_text("ORIGINAL\n")
+    backup_new.write_text("AFTER_FIRST_SWAP\n")
+
+    # Wrong dict order: newer entry comes FIRST in the JSON, older comes
+    # second. Without the explicit-timestamp fix, ``reversed(cli_keys)``
+    # would unwind in the wrong order.
+    mcp_swap.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    state_payload = {
+        "version": 3,
+        "entries": {
+            "claude:user": {
+                "config_path": str(info.config_path),
+                "backup_path": str(backup_new),
+                "server": "libtmux",
+                "action": "replaced",
+                "swapped_at": "20240202020202",  # newer
+            },
+            "claude:project": {
+                "config_path": str(info.config_path),
+                "backup_path": str(backup_old),
+                "server": "libtmux",
+                "action": "replaced",
+                "swapped_at": "20240101010101",  # older
+            },
+        },
+    }
+    mcp_swap.STATE_FILE.write_text(json.dumps(state_payload))
+
+    args = mcp_swap.build_parser().parse_args(["revert", "--cli", "claude"])
+    assert mcp_swap.cmd_revert(args) == 0
+
+    # LIFO order: newer (claude:user) restored first, then older
+    # (claude:project). Final file contents = older backup = "ORIGINAL".
+    assert info.config_path.read_text() == "ORIGINAL\n"
+
+
 def test_legacy_v1_state_migrates_to_v2_keys(
     fake_home: pathlib.Path, fake_repo: pathlib.Path
 ) -> None:

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -1149,3 +1149,70 @@ def test_revert_with_corrupt_seq_no_does_not_crash(
     # dropped at load time; the well-formed entry's revert applies.
     rc = mcp_swap.cmd_revert(parser.parse_args(["revert", "--cli", "claude"]))
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Backup file lifecycle — delete-on-success, keep-on-error.
+# ---------------------------------------------------------------------------
+
+
+def test_revert_deletes_backup_after_successful_restore(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """A successful revert deletes the backup file it just consumed.
+
+    Pre-fix, ``cmd_revert`` restored from ``.bak.mcp-swap-<ts>`` and left
+    the file on disk. Repeated swap/revert cycles let backups accumulate
+    indefinitely. Post-fix matches CPython's
+    ``tempfile.NamedTemporaryFile`` cleanup discipline
+    (``Lib/tempfile.py:614-618``): delete on success, keep on error.
+    """
+    info = mcp_swap.CLIS["cursor"]
+    _write_json(info.config_path, {"mcpServers": {"libtmux": _pinned_json_entry()}})
+    parser = mcp_swap.build_parser()
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                ["use-local", "--repo", str(fake_repo), "--cli", "cursor"]
+            )
+        )
+        == 0
+    )
+    state = mcp_swap.load_state()
+    backup = pathlib.Path(state[("cursor", "user")].backup_path)
+    assert backup.exists()
+
+    assert mcp_swap.cmd_revert(parser.parse_args(["revert", "--cli", "cursor"])) == 0
+    assert not backup.exists()
+
+
+def test_revert_dry_run_keeps_backup(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """``revert --dry-run`` must not delete the backup file.
+
+    The dry-run path ``continue``s before reaching the unlink, so this
+    locks the behaviour against a future refactor that restructures
+    the loop body.
+    """
+    info = mcp_swap.CLIS["cursor"]
+    _write_json(info.config_path, {"mcpServers": {"libtmux": _pinned_json_entry()}})
+    parser = mcp_swap.build_parser()
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                ["use-local", "--repo", str(fake_repo), "--cli", "cursor"]
+            )
+        )
+        == 0
+    )
+    state = mcp_swap.load_state()
+    backup = pathlib.Path(state[("cursor", "user")].backup_path)
+
+    assert (
+        mcp_swap.cmd_revert(
+            parser.parse_args(["revert", "--cli", "cursor", "--dry-run"])
+        )
+        == 0
+    )
+    assert backup.exists()

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -1216,3 +1216,194 @@ def test_revert_dry_run_keeps_backup(
         == 0
     )
     assert backup.exists()
+
+
+# ---------------------------------------------------------------------------
+# `status --scope` filter — completes symmetry with use-local / revert.
+# ---------------------------------------------------------------------------
+
+
+def test_status_scope_user_filters_to_user_only(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``status --scope user`` shows only the user-scope claude line."""
+    info = mcp_swap.CLIS["claude"]
+    _write_json(
+        info.config_path,
+        {
+            "mcpServers": {"libtmux": _pinned_claude_entry()},
+            "projects": {
+                str(fake_repo.resolve()): {
+                    "mcpServers": {"libtmux": _pinned_claude_entry()},
+                },
+            },
+        },
+    )
+    args = mcp_swap.build_parser().parse_args(
+        [
+            "status",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "claude",
+            "--scope",
+            "user",
+        ]
+    )
+    assert mcp_swap.cmd_status(args) == 0
+    out = capsys.readouterr().out
+    assert "[claude:user]" in out
+    assert "[claude:project]" not in out
+
+
+def test_status_scope_project_filters_to_project_only(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``status --scope project`` shows only the project-scope claude line."""
+    info = mcp_swap.CLIS["claude"]
+    _write_json(
+        info.config_path,
+        {
+            "mcpServers": {"libtmux": _pinned_claude_entry()},
+            "projects": {
+                str(fake_repo.resolve()): {
+                    "mcpServers": {"libtmux": _pinned_claude_entry()},
+                },
+            },
+        },
+    )
+    args = mcp_swap.build_parser().parse_args(
+        [
+            "status",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "claude",
+            "--scope",
+            "project",
+        ]
+    )
+    assert mcp_swap.cmd_status(args) == 0
+    out = capsys.readouterr().out
+    assert "[claude:project]" in out
+    assert "[claude:user]" not in out
+
+
+def test_status_no_scope_shows_both_layers(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Without ``--scope``, both Claude layers print when both have entries.
+
+    Locks the existing default behaviour so a future refactor can't
+    silently change it.
+    """
+    info = mcp_swap.CLIS["claude"]
+    _write_json(
+        info.config_path,
+        {
+            "mcpServers": {"libtmux": _pinned_claude_entry()},
+            "projects": {
+                str(fake_repo.resolve()): {
+                    "mcpServers": {"libtmux": _pinned_claude_entry()},
+                },
+            },
+        },
+    )
+    args = mcp_swap.build_parser().parse_args(
+        ["status", "--repo", str(fake_repo), "--cli", "claude"]
+    )
+    assert mcp_swap.cmd_status(args) == 0
+    out = capsys.readouterr().out
+    assert "[claude:user]" in out
+    assert "[claude:project]" in out
+
+
+def test_status_scope_no_op_for_non_claude_cli(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--scope`` is a no-op for non-Claude CLIs (their config has no scope layer).
+
+    Asserts that ``--cli cursor --scope project`` produces the same
+    single ``[cursor]`` line as ``--cli cursor`` alone.
+    """
+    info = mcp_swap.CLIS["cursor"]
+    _write_json(info.config_path, {"mcpServers": {"libtmux": _pinned_json_entry()}})
+    parser = mcp_swap.build_parser()
+
+    # Without --scope.
+    assert (
+        mcp_swap.cmd_status(
+            parser.parse_args(["status", "--repo", str(fake_repo), "--cli", "cursor"])
+        )
+        == 0
+    )
+    out_no_scope = capsys.readouterr().out
+
+    # With --scope project (silently no-op for cursor).
+    assert (
+        mcp_swap.cmd_status(
+            parser.parse_args(
+                [
+                    "status",
+                    "--repo",
+                    str(fake_repo),
+                    "--cli",
+                    "cursor",
+                    "--scope",
+                    "project",
+                ]
+            )
+        )
+        == 0
+    )
+    out_with_scope = capsys.readouterr().out
+
+    assert out_no_scope == out_with_scope
+    assert "[cursor]" in out_with_scope
+
+
+def test_status_scope_user_with_only_project_entry_shows_no_entry(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Filtering to a scope with no entry prints a scope-tagged "no entry" line.
+
+    Locks the symmetry with ``use-local`` / ``revert`` output, which
+    label scope-filtered actions as ``[claude:<scope>]`` rather than
+    falling back to the unscoped ``[claude]`` form.
+    """
+    info = mcp_swap.CLIS["claude"]
+    _write_json(
+        info.config_path,
+        {
+            "projects": {
+                str(fake_repo.resolve()): {
+                    "mcpServers": {"libtmux": _pinned_claude_entry()},
+                },
+            },
+        },
+    )
+    args = mcp_swap.build_parser().parse_args(
+        [
+            "status",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "claude",
+            "--scope",
+            "user",
+        ]
+    )
+    assert mcp_swap.cmd_status(args) == 0
+    out = capsys.readouterr().out
+    assert "[claude:user] no entry for" in out
+    assert "[claude:project]" not in out

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -499,10 +499,10 @@ def test_claude_full_revert_unwinds_both_scopes_in_lifo_order(
     assert not mcp_swap.STATE_FILE.exists()
 
 
-def test_use_local_populates_swapped_at(
+def test_use_local_populates_swapped_at_and_seq_no(
     fake_home: pathlib.Path, fake_repo: pathlib.Path
 ) -> None:
-    """``cmd_use_local`` records the registration timestamp on each entry."""
+    """``cmd_use_local`` records both human-readable timestamp and monotonic seq_no."""
     info = mcp_swap.CLIS["cursor"]
     _write_json(info.config_path, {"mcpServers": {"libtmux": _pinned_json_entry()}})
 
@@ -516,24 +516,62 @@ def test_use_local_populates_swapped_at(
     # ``swapped_at`` is the same ``time.strftime("%Y%m%d%H%M%S")`` value
     # that goes into the backup filename, so checking format suffices.
     assert len(entry.swapped_at) == 14 and entry.swapped_at.isdigit()
-    # And the backup filename embeds the same timestamp.
     assert entry.swapped_at in entry.backup_path
+    # First swap on a clean state starts at zero; subsequent swaps
+    # increment.
+    assert entry.seq_no == 0
 
 
-def test_lifo_revert_orders_by_swapped_at_not_dict_iteration(
+def test_seq_no_increments_across_swaps(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """Each new swap gets ``seq_no = max(existing, default=-1) + 1``."""
+    info_cursor = mcp_swap.CLIS["cursor"]
+    info_gemini = mcp_swap.CLIS["gemini"]
+    _write_json(
+        info_cursor.config_path, {"mcpServers": {"libtmux": _pinned_json_entry()}}
+    )
+    _write_json(
+        info_gemini.config_path, {"mcpServers": {"libtmux": _pinned_json_entry()}}
+    )
+    parser = mcp_swap.build_parser()
+
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                ["use-local", "--repo", str(fake_repo), "--cli", "cursor"]
+            )
+        )
+        == 0
+    )
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                ["use-local", "--repo", str(fake_repo), "--cli", "gemini"]
+            )
+        )
+        == 0
+    )
+
+    state = mcp_swap.load_state()
+    assert state[("cursor", "user")].seq_no == 0
+    assert state[("gemini", "user")].seq_no == 1
+
+
+def test_lifo_revert_orders_by_seq_no_not_dict_iteration(
     fake_home: pathlib.Path,
 ) -> None:
-    """LIFO revert sorts by ``swapped_at`` regardless of state-file dict order.
+    """LIFO revert sorts by ``seq_no`` regardless of state-file dict order.
 
-    Regression test for the pre-explicit-timestamp implementation:
-    ``reversed(cli_keys)`` worked only because dict insertion order
-    happened to match registration order. This test seeds a state file
-    with entries in a *deliberately wrong* dict order — newest first,
-    oldest second — and asserts the revert still applies the newest
-    backup first (true LIFO). With the old `reversed()` approach this
-    would apply the older backup first and leave the file partially
-    rolled back; with the explicit ``swapped_at`` sort it restores
-    correctly regardless of dict order.
+    Regression test for the pre-seq_no implementation: the previous
+    ``(swapped_at, original_index)`` sort fell back to dict iteration
+    order on same-second collisions, and the original ``reversed()``
+    approach was dict-order-dependent throughout. This test seeds a
+    state file with entries in a *deliberately wrong* dict order —
+    higher seq_no first — and asserts the revert still applies the
+    higher-seq_no backup first (true LIFO). The explicit ``seq_no``
+    field makes the sort independent of dict order, JSON round-trip,
+    and wall-clock collisions.
     """
     info = mcp_swap.CLIS["claude"]
     info.config_path.write_text("AFTER_BOTH_SWAPS\n")
@@ -544,26 +582,27 @@ def test_lifo_revert_orders_by_swapped_at_not_dict_iteration(
     backup_old.write_text("ORIGINAL\n")
     backup_new.write_text("AFTER_FIRST_SWAP\n")
 
-    # Wrong dict order: newer entry comes FIRST in the JSON, older comes
-    # second. Without the explicit-timestamp fix, ``reversed(cli_keys)``
-    # would unwind in the wrong order.
+    # Wrong dict order: newer entry (higher seq_no) FIRST in JSON,
+    # older entry (lower seq_no) SECOND. Without the explicit-seq_no
+    # sort, dict iteration would unwind in the wrong direction.
     mcp_swap.STATE_DIR.mkdir(parents=True, exist_ok=True)
     state_payload = {
-        "version": 3,
         "entries": {
             "claude:user": {
                 "config_path": str(info.config_path),
                 "backup_path": str(backup_new),
                 "server": "libtmux",
                 "action": "replaced",
-                "swapped_at": "20240202020202",  # newer
+                "swapped_at": "20240202020202",
+                "seq_no": 1,  # newer
             },
             "claude:project": {
                 "config_path": str(info.config_path),
                 "backup_path": str(backup_old),
                 "server": "libtmux",
                 "action": "replaced",
-                "swapped_at": "20240101010101",  # older
+                "swapped_at": "20240101010101",
+                "seq_no": 0,  # older
             },
         },
     }
@@ -572,8 +611,8 @@ def test_lifo_revert_orders_by_swapped_at_not_dict_iteration(
     args = mcp_swap.build_parser().parse_args(["revert", "--cli", "claude"])
     assert mcp_swap.cmd_revert(args) == 0
 
-    # LIFO order: newer (claude:user) restored first, then older
-    # (claude:project). Final file contents = older backup = "ORIGINAL".
+    # LIFO: seq_no=1 (claude:user) restored first, seq_no=0 (claude:project)
+    # restored second. Final file contents = older backup = "ORIGINAL".
     assert info.config_path.read_text() == "ORIGINAL\n"
 
 
@@ -737,6 +776,7 @@ def test_save_state_writes_atomically(fake_home: pathlib.Path) -> None:
         server="libtmux",
         action="replaced",
         swapped_at="20260101000000",
+        seq_no=0,
     )
     mcp_swap.save_state({("claude", "project"): entry})
 

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -436,6 +436,69 @@ def test_claude_user_and_project_swaps_coexist_independently(
     assert proj_entry["command"] == "uv"
 
 
+def test_claude_full_revert_unwinds_both_scopes_in_lifo_order(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """Reverting both Claude scopes (no ``--scope`` filter) restores the original.
+
+    Regression: forward iteration over the swap-chronological state dict
+    leaves the file in the post-first-swap state because the second
+    backup contains the first swap's modifications. The two backups
+    form a layered stack — they must be unwound in reverse-registration
+    order (LIFO) so each backup peels off its own layer before the
+    prior one is restored. CPython's ``contextlib.ExitStack`` uses the
+    same LIFO discipline for the same reason.
+    """
+    info = mcp_swap.CLIS["claude"]
+    _write_json(
+        info.config_path,
+        {
+            "mcpServers": {"libtmux": _pinned_claude_entry()},
+            "projects": {
+                str(fake_repo.resolve()): {
+                    "mcpServers": {"libtmux": _pinned_claude_entry()},
+                },
+            },
+        },
+    )
+    original = info.config_path.read_bytes()
+    parser = mcp_swap.build_parser()
+
+    # Two swaps in registration order: project first, then user.
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                ["use-local", "--repo", str(fake_repo), "--cli", "claude"]
+            )
+        )
+        == 0
+    )
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                [
+                    "use-local",
+                    "--repo",
+                    str(fake_repo),
+                    "--cli",
+                    "claude",
+                    "--scope",
+                    "user",
+                ]
+            )
+        )
+        == 0
+    )
+
+    # Full revert: no --scope filter — must unwind BOTH layers.
+    assert mcp_swap.cmd_revert(parser.parse_args(["revert", "--cli", "claude"])) == 0
+
+    # Forward iteration would leave the file in the post-first-swap state
+    # (project-scope still local). LIFO restores the true original.
+    assert info.config_path.read_bytes() == original
+    assert not mcp_swap.STATE_FILE.exists()
+
+
 def test_legacy_v1_state_migrates_to_v2_keys(
     fake_home: pathlib.Path, fake_repo: pathlib.Path
 ) -> None:

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -899,3 +899,86 @@ def test_claude_user_scope_delete_server_rejects_non_mapping_mcpServers(
     config: dict[str, t.Any] = {"mcpServers": "not a dict"}
     with pytest.raises(RuntimeError, match="layout appears to have changed"):
         mcp_swap.delete_server("claude", config, "libtmux", fake_repo, scope="user")
+
+
+# ---------------------------------------------------------------------------
+# Graceful CLI error UX — RuntimeError from shape guards must not surface
+# as a Python traceback at the CLI boundary.
+# ---------------------------------------------------------------------------
+
+
+def test_use_local_returns_clean_error_on_malformed_claude_user_mcpServers(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A malformed Claude config produces a clean error + exit 1, no traceback.
+
+    Regression: ``set_server``'s shape guard raises ``RuntimeError`` from
+    ``_claude_user_servers``, which previously propagated past
+    ``cmd_use_local``'s inner ``try/except`` (that one wraps only
+    ``atomic_write`` + ``_revalidate``). Per-CLI ``try/except RuntimeError``
+    around the config-prep region now catches it. Pattern follows pytest's
+    main-level ``UsageError`` formatter in ``_pytest/config/__init__.py``.
+    """
+    info = mcp_swap.CLIS["claude"]
+    info.config_path.parent.mkdir(parents=True, exist_ok=True)
+    info.config_path.write_text(json.dumps({"mcpServers": "not a dict"}))
+
+    rc = mcp_swap.main(
+        [
+            "use-local",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "claude",
+            "--scope",
+            "user",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "[claude:user]" in captured.err
+    assert "layout appears to have changed" in captured.err
+    # No Python traceback should reach the user — only the formatted error.
+    assert "Traceback" not in captured.err
+
+
+def test_status_continues_to_other_clis_on_malformed_claude(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A malformed Claude config does not abort the rest of the status batch.
+
+    Per-CLI continuation: cursor's status line still prints even when
+    Claude's config is corrupt. Same per-CLI continuation pattern
+    ``cmd_use_local`` and ``cmd_revert`` already use.
+    """
+    cursor_info = mcp_swap.CLIS["cursor"]
+    _write_json(
+        cursor_info.config_path, {"mcpServers": {"libtmux": _pinned_json_entry()}}
+    )
+    claude_info = mcp_swap.CLIS["claude"]
+    claude_info.config_path.parent.mkdir(parents=True, exist_ok=True)
+    claude_info.config_path.write_text(json.dumps({"mcpServers": "not a dict"}))
+
+    rc = mcp_swap.main(
+        [
+            "status",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "claude",
+            "--cli",
+            "cursor",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    # Cursor line still printed despite Claude being malformed.
+    assert "[cursor]" in captured.out
+    # Claude error printed to stderr, not stdout — and no traceback.
+    assert "[claude]" in captured.err
+    assert "layout appears to have changed" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -293,6 +293,218 @@ def test_claude_swap_writes_under_repo_abspath_only(
 
 
 # ---------------------------------------------------------------------------
+# Claude --scope {user,project}
+# ---------------------------------------------------------------------------
+
+
+def test_claude_user_scope_writes_top_level_mcpServers(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """``--scope user`` rewrites the top-level fallback, not a per-project node."""
+    info = mcp_swap.CLIS["claude"]
+    _write_json(
+        info.config_path,
+        {"mcpServers": {"libtmux": _pinned_claude_entry()}},
+    )
+    args = mcp_swap.build_parser().parse_args(
+        [
+            "use-local",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "claude",
+            "--scope",
+            "user",
+        ]
+    )
+    assert mcp_swap.cmd_use_local(args) == 0
+
+    after = json.loads(info.config_path.read_text())
+    new_entry = after["mcpServers"]["libtmux"]
+    assert new_entry["command"] == "uv"
+    assert new_entry["args"][0:2] == ["--directory", str(fake_repo.resolve())]
+    # No projects.<abs> node should have been created — user scope must
+    # not bleed into the per-project layer.
+    assert "projects" not in after or str(fake_repo.resolve()) not in after.get(
+        "projects", {}
+    )
+
+
+def test_claude_user_scope_round_trip_restores_byte_identical(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """``--scope user`` swap then revert yields byte-identical bytes."""
+    info = mcp_swap.CLIS["claude"]
+    _write_json(
+        info.config_path,
+        {"mcpServers": {"libtmux": _pinned_claude_entry()}},
+    )
+    original = info.config_path.read_bytes()
+
+    swap_args = mcp_swap.build_parser().parse_args(
+        [
+            "use-local",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "claude",
+            "--scope",
+            "user",
+        ]
+    )
+    assert mcp_swap.cmd_use_local(swap_args) == 0
+    assert info.config_path.read_bytes() != original  # sanity
+
+    revert_args = mcp_swap.build_parser().parse_args(
+        ["revert", "--cli", "claude", "--scope", "user"]
+    )
+    assert mcp_swap.cmd_revert(revert_args) == 0
+    assert info.config_path.read_bytes() == original
+
+
+def test_claude_user_and_project_swaps_coexist_independently(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """Running both scopes leaves two distinct state entries with separate backups."""
+    info = mcp_swap.CLIS["claude"]
+    # Seed both layers with PyPI-style entries so the swap has something
+    # to replace in each scope.
+    _write_json(
+        info.config_path,
+        {
+            "mcpServers": {"libtmux": _pinned_claude_entry()},
+            "projects": {
+                str(fake_repo.resolve()): {
+                    "mcpServers": {"libtmux": _pinned_claude_entry()},
+                },
+            },
+        },
+    )
+    parser = mcp_swap.build_parser()
+
+    # First swap: project scope (the legacy default).
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                ["use-local", "--repo", str(fake_repo), "--cli", "claude"]
+            )
+        )
+        == 0
+    )
+    # Second swap: user scope.
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                [
+                    "use-local",
+                    "--repo",
+                    str(fake_repo),
+                    "--cli",
+                    "claude",
+                    "--scope",
+                    "user",
+                ]
+            )
+        )
+        == 0
+    )
+
+    state = mcp_swap.load_state()
+    assert ("claude", "project") in state
+    assert ("claude", "user") in state
+    assert (
+        state[("claude", "project")].backup_path
+        != state[("claude", "user")].backup_path
+    )
+
+    # Revert just user-scope; project entry must remain intact.
+    assert (
+        mcp_swap.cmd_revert(
+            parser.parse_args(["revert", "--cli", "claude", "--scope", "user"])
+        )
+        == 0
+    )
+    state_after = mcp_swap.load_state()
+    assert ("claude", "user") not in state_after
+    assert ("claude", "project") in state_after
+
+    after = json.loads(info.config_path.read_text())
+    # User-level back to PyPI shape.
+    assert after["mcpServers"]["libtmux"]["command"] == "uvx"
+    # Project-level still local.
+    proj_entry = after["projects"][str(fake_repo.resolve())]["mcpServers"]["libtmux"]
+    assert proj_entry["command"] == "uv"
+
+
+def test_legacy_v1_state_migrates_to_v2_keys(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """A v1 state file with bare ``cli`` keys is migrated on load.
+
+    ``claude`` (legacy default was per-project) → ``("claude", "project")``.
+    Bare ``codex`` / ``cursor`` / ``gemini`` (no per-project layer) →
+    ``("<cli>", "user")``.
+    """
+    mcp_swap.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "version": 1,
+        "entries": {
+            "claude": {
+                "config_path": "/tmp/.claude.json",
+                "backup_path": "/tmp/.claude.json.bak",
+                "server": "libtmux",
+                "action": "replaced",
+            },
+            "codex": {
+                "config_path": "/tmp/codex.toml",
+                "backup_path": "/tmp/codex.toml.bak",
+                "server": "libtmux",
+                "action": "added",
+            },
+        },
+    }
+    mcp_swap.STATE_FILE.write_text(json.dumps(legacy))
+
+    state = mcp_swap.load_state()
+    assert set(state.keys()) == {("claude", "project"), ("codex", "user")}
+    assert state[("claude", "project")].backup_path == "/tmp/.claude.json.bak"
+    assert state[("codex", "user")].action == "added"
+
+
+def test_non_claude_scope_user_passes_through_to_global_config(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """``--scope`` is a no-op for non-Claude CLIs (their config has no scope layer)."""
+    info = mcp_swap.CLIS["cursor"]
+    _write_json(info.config_path, {"mcpServers": {"libtmux": _pinned_json_entry()}})
+
+    # Pass --scope user explicitly: should write the same global entry as
+    # if the flag were absent (cursor has no per-project layer).
+    args = mcp_swap.build_parser().parse_args(
+        [
+            "use-local",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "cursor",
+            "--scope",
+            "user",
+        ]
+    )
+    assert mcp_swap.cmd_use_local(args) == 0
+
+    after = json.loads(info.config_path.read_text())
+    assert after["mcpServers"]["libtmux"]["command"] == "uv"
+
+    # State key reflects the normalised scope, not the raw flag value.
+    state = mcp_swap.load_state()
+    assert ("cursor", "user") in state
+    # And the bizarre case "--scope project" against a non-Claude CLI is
+    # silently coerced to user, not stored as a phantom (cursor, project).
+    assert ("cursor", "project") not in state
+
+
+# ---------------------------------------------------------------------------
 # Codex TOML — format preservation + add-when-missing
 # ---------------------------------------------------------------------------
 

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -337,7 +337,8 @@ def test_codex_adds_block_when_absent_and_revert_removes_it(
     )
     assert mcp_swap.cmd_use_local(args) == 0
     state = mcp_swap.load_state()
-    assert state["codex"].action == "added"
+    # Codex has no per-project layer, so its scope is always "user".
+    assert state[("codex", "user")].action == "added"
 
     revert_args = mcp_swap.build_parser().parse_args(["revert", "--cli", "codex"])
     assert mcp_swap.cmd_revert(revert_args) == 0
@@ -418,11 +419,11 @@ def test_save_state_writes_atomically(fake_home: pathlib.Path) -> None:
         server="libtmux",
         action="replaced",
     )
-    mcp_swap.save_state({"claude": entry})
+    mcp_swap.save_state({("claude", "project"): entry})
 
     assert mcp_swap.STATE_FILE.exists()
     payload = json.loads(mcp_swap.STATE_FILE.read_text())
-    assert payload["entries"]["claude"]["server"] == "libtmux"
+    assert payload["entries"]["claude:project"]["server"] == "libtmux"
 
     # tempfile.mkstemp writes siblings prefixed "<name>." — none should
     # remain after a successful atomic_write.

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -982,3 +982,170 @@ def test_status_continues_to_other_clis_on_malformed_claude(
     assert "[claude]" in captured.err
     assert "layout appears to have changed" in captured.err
     assert "Traceback" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# State-file resilience — hand-edited corruption must not crash the script.
+# Schema is internal (no compat contract) so the policy is "drop on parse
+# failure", consistent with how malformed state-file keys already behave.
+# ---------------------------------------------------------------------------
+
+
+def test_load_state_drops_entries_with_non_int_seq_no(
+    fake_home: pathlib.Path,
+) -> None:
+    """A non-coercible ``seq_no`` is dropped at load time.
+
+    Same drop-on-malformed posture as :func:`mcp_swap._parse_state_key`:
+    schema is internal, so a hand-edited file with corrupt counter
+    values is silently skipped rather than crashing.
+    """
+    mcp_swap.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "entries": {
+            "claude:user": {
+                "config_path": "/tmp/cfg.json",
+                "backup_path": "/tmp/cfg.json.bak",
+                "server": "libtmux",
+                "action": "replaced",
+                "swapped_at": "20260101000000",
+                "seq_no": "not-an-int",  # corrupted
+            },
+            "claude:project": {
+                "config_path": "/tmp/cfg.json",
+                "backup_path": "/tmp/cfg.json.bak2",
+                "server": "libtmux",
+                "action": "replaced",
+                "swapped_at": "20260101000001",
+                "seq_no": 1,  # well-formed
+            },
+        },
+    }
+    mcp_swap.STATE_FILE.write_text(json.dumps(payload))
+
+    state = mcp_swap.load_state()
+    assert ("claude", "user") not in state
+    assert ("claude", "project") in state
+    assert state[("claude", "project")].seq_no == 1
+
+
+def test_load_state_coerces_numeric_string_seq_no(
+    fake_home: pathlib.Path,
+) -> None:
+    """A numeric-string ``seq_no`` is coerced via ``int()``, not dropped.
+
+    Distinguishes "user typed quotes around the number" from "user
+    typed something non-numeric": the former should still load
+    cleanly, the latter should drop.
+    """
+    mcp_swap.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "entries": {
+            "cursor:user": {
+                "config_path": "/tmp/cfg.json",
+                "backup_path": "/tmp/cfg.json.bak",
+                "server": "libtmux",
+                "action": "replaced",
+                "swapped_at": "20260101000000",
+                "seq_no": "3",  # numeric string — coerce
+            },
+        },
+    }
+    mcp_swap.STATE_FILE.write_text(json.dumps(payload))
+
+    state = mcp_swap.load_state()
+    assert ("cursor", "user") in state
+    assert state[("cursor", "user")].seq_no == 3
+
+
+def test_load_state_drops_entries_with_missing_required_fields(
+    fake_home: pathlib.Path,
+) -> None:
+    """Entries missing required SwapEntry fields are dropped, not raised.
+
+    Pre-fix, ``SwapEntry(**v)`` raised ``TypeError: missing 1 required
+    positional argument: 'seq_no'`` and aborted the load. Post-fix,
+    :func:`mcp_swap._parse_state_entry` catches ``TypeError`` and
+    returns ``None``, dropping the entry.
+    """
+    mcp_swap.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "entries": {
+            "cursor:user": {
+                # Missing seq_no entirely.
+                "config_path": "/tmp/cfg.json",
+                "backup_path": "/tmp/cfg.json.bak",
+                "server": "libtmux",
+                "action": "replaced",
+                "swapped_at": "20260101000000",
+            },
+        },
+    }
+    mcp_swap.STATE_FILE.write_text(json.dumps(payload))
+
+    state = mcp_swap.load_state()
+    assert state == {}
+
+
+def test_revert_with_corrupt_seq_no_does_not_crash(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+) -> None:
+    """Same-CLI two-scope state with one corrupt ``seq_no`` does not raise TypeError.
+
+    Regression: the LIFO sort at ``cmd_revert`` would compare ``int`` vs
+    ``str`` (``int < str`` raises in Python 3) when two same-CLI
+    entries existed and one had a hand-edited corrupt counter.
+    Cross-CLI buckets are length-1 and never invoke comparison —
+    making the failure mode asymmetric, only triggering on Claude
+    project + user. Validating at load time eliminates the
+    asymmetry: the corrupt entry is dropped before it reaches the
+    sort, so the well-formed entry's revert applies normally.
+    """
+    info = mcp_swap.CLIS["claude"]
+    _write_json(
+        info.config_path,
+        {
+            "mcpServers": {"libtmux": _pinned_claude_entry()},
+            "projects": {
+                str(fake_repo.resolve()): {
+                    "mcpServers": {"libtmux": _pinned_claude_entry()},
+                },
+            },
+        },
+    )
+    parser = mcp_swap.build_parser()
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                ["use-local", "--repo", str(fake_repo), "--cli", "claude"]
+            )
+        )
+        == 0
+    )
+    assert (
+        mcp_swap.cmd_use_local(
+            parser.parse_args(
+                [
+                    "use-local",
+                    "--repo",
+                    str(fake_repo),
+                    "--cli",
+                    "claude",
+                    "--scope",
+                    "user",
+                ]
+            )
+        )
+        == 0
+    )
+
+    # Hand-edit one of the two entries to corrupt seq_no.
+    raw = json.loads(mcp_swap.STATE_FILE.read_text())
+    raw["entries"]["claude:user"]["seq_no"] = "not-an-int"
+    mcp_swap.STATE_FILE.write_text(json.dumps(raw))
+
+    # Revert must NOT raise TypeError. The corrupt entry is silently
+    # dropped at load time; the well-formed entry's revert applies.
+    rc = mcp_swap.cmd_revert(parser.parse_args(["revert", "--cli", "claude"]))
+    assert rc == 0


### PR DESCRIPTION
## Summary

- **Add** `--scope {user,project}` to `scripts/mcp_swap.py`'s `use-local` and `revert` subcommands. `--scope user` rewrites Claude's top-level `mcpServers` fallback (every project without an override picks it up); `--scope project` (the default — preserves pre-flag behaviour) writes the per-project `projects[<abs>].mcpServers` entry.
- **Migrate** state-file schema to v2: keys go from bare `cli` strings to `f"{cli}:{scope}"` so a single Claude install can hold both scopes simultaneously with independent backups. v1 entries migrate transparently on load (`claude` → `("claude","project")`; others → `("<cli>","user")`).
- **Fix** a real backup-collision bug surfaced by the coexist test — two Claude swaps inside the same second produced identical backup filenames, so the second swap's backup overwrote the first's. Backup suffix now embeds the scope for Claude (non-Claude filenames stay byte-compatible with v1).
- **Document** the new flag in `scripts/README.md` with a "Scope" subsection and the layered-config explanation that motivates it.

## Motivation

`mcp_swap.py` was conservative by design — it only wrote under the current repo's per-project key in `~/.claude.json`, leaving every other project's MCP entry untouched. Side-effect: when QA-ing a libtmux-mcp branch from any non-libtmux-mcp directory (e.g. `~/work/cv`), Claude kept resolving the user-level fallback to the PyPI release. The flag adds an explicit "yes, swap the global default" path without losing the safe-by-default per-project behaviour.

## Changes by area

### Script (`scripts/mcp_swap.py`)

- **`Scope` literal + helpers**: New `Scope = Literal["user","project"]`, plus `_normalize_scope` (coerces non-Claude scope to `"user"`), `_state_key`, and `_parse_state_key` (the v1→v2 migration shim). All centralised so the rest of the file just threads `scope` through.
- **`get_server` / `set_server` / `delete_server`**: New keyword-only `scope` parameter (default `"project"`). Claude branches gate on it; non-Claude branches ignore it. `_claude_project_node` is unchanged — only called when `scope == "project"`.
- **`load_state` / `save_state` / `clear_state`**: Switched from `dict[CLIName, SwapEntry]` to `dict[tuple[CLIName, Scope], SwapEntry]`. Migration runs in `load_state` via `_parse_state_key`; unknown keys are dropped silently.
- **`cmd_status`**: For Claude, prints separate `[claude:user]` / `[claude:project]` lines when both have entries (or one if only one exists). Non-Claude CLIs continue to print one `[<cli>]` line.
- **`cmd_use_local` / `cmd_revert`**: Read `args.scope`, normalise per CLI, key state by `(cli, scope)`. `revert` without `--scope` rolls back every recorded scope for the targeted CLIs; with `--scope`, only that one.
- **`build_parser`**: New `--scope` argument on `use-local` and `revert` with `choices=ALL_SCOPES` and `default=None`.
- **Backup suffix**: For Claude, embeds the scope to disambiguate within-second collisions. Non-Claude suffix unchanged.

### Tests (`tests/test_mcp_swap.py`)

| Test | Validates |
|---|---|
| `test_claude_user_scope_writes_top_level_mcpServers` | `--scope user` writes `mcpServers` and creates no `projects[<abs>]` node |
| `test_claude_user_scope_round_trip_restores_byte_identical` | swap → revert at user-scope yields byte-identical bytes |
| `test_claude_user_and_project_swaps_coexist_independently` | Both scopes can swap with separate backups; reverting one leaves the other intact |
| `test_legacy_v1_state_migrates_to_v2_keys` | Bare-`cli` v1 keys load as the right `(cli, scope)` tuple |
| `test_non_claude_scope_user_passes_through_to_global_config` | `--scope` is silently coerced for non-Claude CLIs; never produces a phantom `(cursor, project)` |

Two existing tests were updated to use the new `(cli, scope)` tuple keys (`test_codex_adds_block_when_absent_and_revert_removes_it`, `test_save_state_writes_atomically`).

### Docs

- `scripts/README.md` — new "`--scope {user,project}` (Claude only)" subsection with the two-layer config explanation, the silent-coerce-for-others rule, and the simultaneous-scopes paragraph. Safety section updated to note the scope-suffixed Claude backups and the v2 schema with v1 migration.
- `CHANGES` — entry under `### Development` (per project convention: dev tooling is not shipped product surface).

## Design decisions

- **Default `--scope project`**: keeps every existing call site — including `just mcp-use-local` from the libtmux-mcp repo itself — behaviourally identical. The flag is purely additive.
- **Silent coerce for non-Claude CLIs instead of erroring**: Codex / Cursor / Gemini have no per-project layer in their config files, so `--scope` is meaningless for them. Erroring would create friction in scripts that pass `--scope user` for cross-CLI consistency. `_normalize_scope` does the coerce in one spot.
- **Tuple keys (`(cli, scope)`) in memory; `cli:scope` strings on disk**: Tuple gives static guarantees on key shape; the string form is friendlier for the JSON file and stays human-editable.
- **v1 migration in `_parse_state_key`, not at write time**: `save_state` always emits v2; the migration runs once whenever a v1 file is read, then disappears on the next write. No long-lived "v1-mode" state to leak.
- **Scope in Claude backup suffix; non-Claude unchanged**: only Claude can produce same-second swap collisions (two scopes, one config file). Adding the suffix universally would break byte-compatibility with existing v1 `*.bak.mcp-swap-<ts>` files for users mid-revert.

## Verification

The flag-related code paths are all in `scripts/mcp_swap.py`:

```bash
rg -n 'scope' scripts/mcp_swap.py
```

State-file schema bump is reflected at one constant:

```bash
rg -n 'STATE_VERSION' scripts/mcp_swap.py
```

The two existing tests that reach into the in-memory state dict were updated; no other test file references the swap state shape:

```bash
rg -n '("claude"|"codex"|"cursor"|"gemini")\s*[:,].*Swap' tests/
```

## Test plan

- [x] `test_claude_user_scope_writes_top_level_mcpServers` — user-scope writes `mcpServers`, leaves `projects[<abs>]` untouched
- [x] `test_claude_user_scope_round_trip_restores_byte_identical` — round-trip preserves bytes
- [x] `test_claude_user_and_project_swaps_coexist_independently` — both scopes coexist; selective revert works
- [x] `test_legacy_v1_state_migrates_to_v2_keys` — v1 keys (`claude`, `codex`, ...) migrate to `(cli, scope)` tuples
- [x] `test_non_claude_scope_user_passes_through_to_global_config` — `--scope` silently coerced for non-Claude
- [x] All 18 existing `tests/test_mcp_swap.py` tests still pass (two updated for new key shape)
- [x] `just ruff` — clean
- [x] `just ruff-format` — no diff
- [x] `just mypy` — strict, zero errors
- [x] `uv run pytest --reruns 0` — full suite green
- [x] `rm -rf docs/_build && just build-docs` — same warning baseline as `main`

## Manual QA (real configs, post-backup)

Run from `/home/d/work/python/libtmux-mcp` after backing up `~/.claude.json` / `~/.codex/config.toml` / `~/.cursor/mcp.json` / `~/.gemini/settings.json` to a safe location:

```bash
just mcp-status                                                            # baseline shows [claude:user] PyPI + [claude:project] local
uv run scripts/mcp_swap.py use-local --cli claude --scope user --dry-run   # diff preview
uv run scripts/mcp_swap.py use-local --cli claude --scope user             # swap
(cd ~/work/cv && claude mcp list | grep libtmux)                           # → "uv --directory ... run libtmux-mcp"
uv run scripts/mcp_swap.py revert --cli claude --scope user                # revert just user-scope
(cd ~/work/cv && claude mcp list | grep libtmux)                           # → "uvx --no-config libtmux-mcp" (rolled back)
just mcp-status                                                            # project-scope still local
```

Confirmed end-to-end on this branch. The user-scope swap reaches every project that has no per-project override; reverting it leaves the per-project libtmux-mcp swap intact.