### PR TITLE
docs: kill install-widget layout flash + first-paint FOUT polish

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,9 +13,9 @@ _Notes on upcoming releases will be added here_
   `sphinx-vite-builder` handling theme-asset builds (#33)
 - Eliminate first-paint jank on the docs site: `{mcp-install}` no
   longer flashes when restoring a saved client/method from
-  `localStorage` (CLS drops to 0), and the sidebar logo plus
-  bold/italic text in headings and the announcement bar no longer
-  pop in late as fonts arrive. (#36)
+  `localStorage` (CLS drops to 0), and the sidebar logo plus all
+  bold and italic text no longer pop in late as fonts arrive.
+  (#36)
 
 ## libtmux-mcp 0.1.0a4 (2026-05-02)
 

--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,18 @@ _Notes on upcoming releases will be added here_
 - Bump gp-sphinx docs stack to v0.0.1a16 — docs site now renders
   via `gp-furo-theme`, a Tailwind v4 respin of Furo, with
   `sphinx-vite-builder` handling theme-asset builds (#33)
+- {mcp-install} no longer flashes on initial paint when a non-default
+  `(client, method)` is saved in `localStorage`. The prehydrate
+  `<style>` was unlayered while `gp-furo-theme` ships Tailwind
+  preflight's `[hidden]:where(...){display:none!important}` inside
+  `@layer base`; per CSS Cascade Level 5, `!important` rules in any
+  layer outrank `!important` unlayered rules regardless of selector
+  specificity, so the saved panel painted as `display:none` until
+  `widget.js` ran. Wrapping the prehydrate rules in
+  `@layer mcp-install-prehydrate` (declared first in `<head>` so it
+  becomes the highest-priority layer for `!important`) makes the
+  saved panel paint correctly on the first frame. Cumulative Layout
+  Shift on `/` drops from 0.0299 to 0.
 
 ## libtmux-mcp 0.1.0a4 (2026-05-02)
 

--- a/CHANGES
+++ b/CHANGES
@@ -11,18 +11,11 @@ _Notes on upcoming releases will be added here_
 - Bump gp-sphinx docs stack to v0.0.1a16 — docs site now renders
   via `gp-furo-theme`, a Tailwind v4 respin of Furo, with
   `sphinx-vite-builder` handling theme-asset builds (#33)
-- {mcp-install} no longer flashes on initial paint when a non-default
-  `(client, method)` is saved in `localStorage`. The prehydrate
-  `<style>` was unlayered while `gp-furo-theme` ships Tailwind
-  preflight's `[hidden]:where(...){display:none!important}` inside
-  `@layer base`; per CSS Cascade Level 5, `!important` rules in any
-  layer outrank `!important` unlayered rules regardless of selector
-  specificity, so the saved panel painted as `display:none` until
-  `widget.js` ran. Wrapping the prehydrate rules in
-  `@layer mcp-install-prehydrate` (declared first in `<head>` so it
-  becomes the highest-priority layer for `!important`) makes the
-  saved panel paint correctly on the first frame. Cumulative Layout
-  Shift on `/` drops from 0.0299 to 0.
+- Eliminate first-paint jank on the docs site: `{mcp-install}` no
+  longer flashes when restoring a saved client/method from
+  `localStorage` (CLS drops to 0), and the sidebar logo plus
+  bold/italic text in headings and the announcement bar no longer
+  pop in late as fonts arrive. (#36)
 
 ## libtmux-mcp 0.1.0a4 (2026-05-02)
 

--- a/docs/_ext/widgets/_prehydrate.py
+++ b/docs/_ext/widgets/_prehydrate.py
@@ -26,20 +26,29 @@ if t.TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 
+# Every prehydrate declaration is ``!important``. The whole block lives in
+# ``@layer mcp-install-prehydrate`` (see :func:`_build_style`) and per CSS
+# Cascade Level 5 only ``!important`` declarations get the layer-priority
+# *reversal* that makes a layered rule outrank an unlayered one. Normal
+# (non-``!important``) rules in a layer LOSE to unlayered rules of the same
+# specificity — which is what bit the original tab rules: they were
+# specific enough to beat ``widget.css``'s ``.tab[aria-selected="true"]``
+# unlayered, but became powerless once we wrapped the prehydrate in a layer
+# to fix the panel cascade against ``furo-tw``'s ``[hidden]`` preflight.
 _TAB_DEACTIVATE_RULE = (
     "html[data-mcp-install-client] .lm-mcp-install__tab"
     '[data-tab-kind="client"][aria-selected="true"],'
     "html[data-mcp-install-method] .lm-mcp-install__tab"
     '[data-tab-kind="method"][aria-selected="true"]'
-    "{color:var(--color-foreground-muted);"
-    "border-bottom-color:transparent;"
-    "background:transparent}"
+    "{color:var(--color-foreground-muted) !important;"
+    "border-bottom-color:transparent !important;"
+    "background:transparent !important}"
 )
 
 _TAB_ACTIVE_DECL = (
-    "{color:var(--color-brand-primary);"
-    "border-bottom-color:var(--color-brand-primary);"
-    "background:var(--color-background-primary)}"
+    "{color:var(--color-brand-primary) !important;"
+    "border-bottom-color:var(--color-brand-primary) !important;"
+    "background:var(--color-background-primary) !important}"
 )
 
 _PANEL_HIDE_RULE = (
@@ -101,6 +110,14 @@ def _build_style() -> str:
     makes them the *first* layer the browser encounters (the prehydrate
     ``<style>`` lives in ``metatags``, before any ``<link>``), which is
     the highest-priority layer for ``!important``.
+
+    The reversal only applies to ``!important`` declarations. *Normal*
+    layered rules LOSE to *normal* unlayered rules — so every declaration
+    here is ``!important``, including the tab active/inactive colours
+    that competed (and won, unlayered) against ``widget.css``'s
+    ``.lm-mcp-install__tab[aria-selected="true"]`` purely on specificity.
+    Drop the ``!important`` on a tab declaration and the active-tab
+    indicator will flash from server default to saved state on first paint.
     """
     client_ids = tuple(c.id for c in CLIENTS)
     method_ids = tuple(m.id for m in METHODS)

--- a/docs/_ext/widgets/_prehydrate.py
+++ b/docs/_ext/widgets/_prehydrate.py
@@ -88,6 +88,19 @@ def _build_style() -> str:
     Selectors are enumerated from :data:`CLIENTS` / :data:`METHODS` so adding
     a client or method auto-extends the prehydrate rules — no second source of
     truth to drift from.
+
+    Rules are wrapped in ``@layer mcp-install-prehydrate``. ``gp-furo-theme``
+    ships Tailwind v4's preflight inside ``@layer base``, including
+    ``[hidden]:where(:not([hidden="until-found"])){display:none!important}``.
+    Per CSS Cascade Level 5, important-rule layer ordering is reversed:
+    rules in *any* cascade layer outrank ``!important`` unlayered rules
+    regardless of specificity. An unlayered prehydrate ``<style>`` therefore
+    loses to the preflight on the saved panel, so the saved panel paints as
+    ``display:none`` until ``widget.js`` mutates ``[hidden]`` and the
+    install widget visibly grows. Declaring our rules in their own layer
+    makes them the *first* layer the browser encounters (the prehydrate
+    ``<style>`` lives in ``metatags``, before any ``<link>``), which is
+    the highest-priority layer for ``!important``.
     """
     client_ids = tuple(c.id for c in CLIENTS)
     method_ids = tuple(m.id for m in METHODS)
@@ -98,7 +111,7 @@ def _build_style() -> str:
         _PANEL_HIDE_RULE,
         _panel_active_selectors(client_ids, method_ids) + _PANEL_ACTIVE_DECL,
     ]
-    return "<style>" + "".join(rules) + "</style>"
+    return "<style>@layer mcp-install-prehydrate{" + "".join(rules) + "}</style>"
 
 
 def _snippet() -> str:

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,23 @@
+{# Project-local override of gp-furo/base.html's logo prefetch hints.
+   gp-furo's default emits <link rel="prefetch"> for logos, which Chrome
+   treats as Lowest priority for a future navigation — so the sidebar
+   <img> first encounter triggers a fresh network request and the logo
+   pops in late. We use this logo on the current page, not a future one,
+   so rel="preload" is the correct hint. Also: light_logo and dark_logo
+   are the same file in this project, so emit a single tag (the browser
+   would dedupe URL-identical requests anyway, but two tags is noise).
+#}
+{% extends "!page.html" %}
+
+{% block logo_prefetch_links %}
+{%- if logo_url -%}
+<link rel="preload" href="{{ logo_url }}" as="image">
+{%- elif theme_light_logo and theme_dark_logo -%}
+{%- set light_path = pathto('_static/' + theme_light_logo, 1) -%}
+{%- set dark_path = pathto('_static/' + theme_dark_logo, 1) -%}
+<link rel="preload" href="{{ light_path }}" as="image">
+{%- if dark_path != light_path %}
+<link rel="preload" href="{{ dark_path }}" as="image">
+{%- endif -%}
+{%- endif -%}
+{% endblock %}

--- a/docs/_widgets/mcp-install/widget.js
+++ b/docs/_widgets/mcp-install/widget.js
@@ -5,6 +5,12 @@
  * localStorage state is re-applied on DOMContentLoaded and on every
  * gp-sphinx:navigated event (see sphinx-gp-theme's README for the contract).
  *
+ * Visibility is fully CSS-driven by <html data-mcp-install-*> attrs and the
+ * @layer mcp-install-prehydrate rules in docs/_ext/widgets/_prehydrate.py.
+ * This script never mutates the panels' [hidden] attributes — it only
+ * keeps tab aria-selected and the <html> data-attrs in sync with the
+ * current selection. The CSS handles the rest.
+ *
  * Vanilla JS, no deps.
  */
 (function () {
@@ -76,13 +82,20 @@
     });
     if (!found) return; // value not available in this widget — ignore.
 
-    updatePanels(widget);
+    // Mirror current widget state onto <html> so _prehydrate.py's
+    // @layer mcp-install-prehydrate selectors drive panel visibility.
+    // Both attrs must be present for _panel_active to match, so set them
+    // unconditionally on every selection — including the click-before-saved
+    // case where the user picks a method without ever choosing a client
+    // (the other kind still has its server-default aria-selected to read).
+    var html = document.documentElement;
+    var clientValue = selectedValue(widget, "client");
+    var methodValue = selectedValue(widget, "method");
+    if (clientValue) html.setAttribute("data-mcp-install-client", clientValue);
+    if (methodValue) html.setAttribute("data-mcp-install-method", methodValue);
 
     if (opts.persist) {
       localStorage.setItem(STORAGE[kind], value);
-      // Keep <html> attr in sync so the prehydrate CSS in _prehydrate.py
-      // continues to drive active state across SPA navigations after a click.
-      document.documentElement.setAttribute("data-mcp-install-" + kind, value);
     }
     if (opts.broadcast) {
       window.dispatchEvent(
@@ -91,16 +104,6 @@
         })
       );
     }
-  }
-
-  function updatePanels(widget) {
-    var client = selectedValue(widget, "client");
-    var method = selectedValue(widget, "method");
-    widget.querySelectorAll(".lm-mcp-install__panel").forEach(function (panel) {
-      var match = panel.dataset.client === client && panel.dataset.method === method;
-      if (match) panel.removeAttribute("hidden");
-      else panel.setAttribute("hidden", "");
-    });
   }
 
   function selectedValue(widget, kind) {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,7 @@ import sys
 import typing as t
 
 from gp_sphinx.config import make_linkcode_resolve, merge_sphinx_config
+from gp_sphinx.defaults import DEFAULT_SPHINX_FONT_PRELOAD
 
 import libtmux_mcp
 
@@ -64,6 +65,17 @@ conf = merge_sphinx_config(
     rediraffe_redirects="redirects.txt",
     copybutton_selector="div.highlight pre, div.admonition.prompt > p:last-child",
     copybutton_exclude=".linenos, .admonition-title",
+    # gp-sphinx's default preloads only Sans 400/700 + Mono 400. furo-tw.css
+    # uses Sans 500 (h1-h6, sidebar labels, definition list terms) and 600
+    # (blockquote.epigraph). Without preload, those weights download lazily
+    # after first paint and the heading text visibly re-flows when the
+    # font finally lands (font-display: block hides the text for ~3s
+    # then swaps, so it reads as a flicker rather than fallback-then-real).
+    sphinx_font_preload=[
+        *DEFAULT_SPHINX_FONT_PRELOAD,
+        ("IBM Plex Sans", 500, "normal"),
+        ("IBM Plex Sans", 600, "normal"),
+    ],
 )
 
 conf["myst_enable_extensions"] = [*conf["myst_enable_extensions"], "attrs_inline"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,11 @@ conf = merge_sphinx_config(
         *DEFAULT_SPHINX_FONT_PRELOAD,
         ("IBM Plex Sans", 500, "normal"),
         ("IBM Plex Sans", 600, "normal"),
+        # The announcement bar contains <em>Pre-alpha.</em>, which
+        # resolves to 400 italic. Without preload, it loads ~54 ms
+        # after the preloaded normal weights and the announcement
+        # italic pops in late on first paint.
+        ("IBM Plex Sans", 400, "italic"),
     ],
 )
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,11 @@ conf = merge_sphinx_config(
         # after the preloaded normal weights and the announcement
         # italic pops in late on first paint.
         ("IBM Plex Sans", 400, "italic"),
+        # Bold inline code (<strong><code>, ~14 hits on the index)
+        # uses Mono 700. Without preload, it loads ~30 ms after the
+        # other critical fonts and bold inline code transiently
+        # renders at fallback weight before swap.
+        ("IBM Plex Mono", 700, "normal"),
     ],
 )
 


### PR DESCRIPTION
## Summary

- **Fix** install-widget layout flash: with a non-default `(client, method)` saved in `localStorage`, the widget grew from ~94 px to ~270 px after `widget.js` ran, pushing the `sd-container-fluid` grid below it down by ~176 px. CLS on `/` drops **0.0299 → 0** (verified in Playwright with the worst-case `(cursor, pip)` saved state).
- **Fix** install-widget active-tab indicator flash: tabs visibly switched from server default (`claude-code` / `uvx`) to the saved selection on first paint. Same cascade root cause as the panel flash.
- **Fix** heading FOUT: `h1`–`h6` and sidebar labels render at weight 500, but only weights 400/700 were preloaded. Headings popped in late while weight-500 fetched lazily.
- **Fix** announcement-bar italic FOUT: `<em>Pre-alpha.</em>` resolves to weight 400 italic, which was loading at t=65 ms (CSS-initiated) instead of parallel with the rest of the critical fonts at t=11 ms.
- **Fix** sidebar logo flash: `gp-furo-theme` emits `<link rel="prefetch">` for the logo, which Chrome treats as Lowest priority for a *future* navigation. Switched to `rel="preload"` since the logo paints on the current page.
- **Refactor** `widget.js`: removed `updatePanels()` — visibility is now fully CSS-driven by `<html data-mcp-install-*>` attrs. Server-rendered `[hidden]` state is never mutated post-load.

## Root cause: CSS Cascade Level 5 layer ordering

The install-widget had a prehydrate mechanism (`docs/_ext/widgets/_prehydrate.py`, introduced 2026-04-27) that injects an inline `<head>` `<style>` to drive panel visibility from `<html>` data-attrs before first paint. It stopped working after the docs migrated to `gp-furo-theme` (gp-sphinx 0.0.1a16, #33), which ships Tailwind v4's preflight inside `@layer base`:

```css
@layer base { [hidden]:where(:not([hidden="until-found"])){display:none!important} }
```

Per [CSS Cascade Level 5][cascade-5], `!important` rules in *any* cascade layer outrank `!important` unlayered rules — specificity does not enter the comparison. The prehydrate's `(0,5,1)` selector lost to Tailwind's `(0,1,0)` purely because Tailwind's was layered and the prehydrate's was not.

Verified at runtime: inserting `_panel_active` into `@layer base` in DevTools flips the saved panel from `display:none` to `display:block` immediately. The fix wraps the prehydrate rules in `@layer mcp-install-prehydrate`, which the prehydrate `<style>` declares first in `<head>` (it lives in `metatags`, before any `<link rel="stylesheet">`) — making it the *earliest* layer and therefore the highest-priority layer for `!important`.

[cascade-5]: https://www.w3.org/TR/css-cascade-5/#layer-ordering

## Changes by area

### Install widget cascade

- **`docs/_ext/widgets/_prehydrate.py`**: Wrap the joined rules in `@layer mcp-install-prehydrate { … }`. Mark every tab declaration `!important` (the layer reversal applies *only* to `!important` — *normal* layered rules LOSE to *normal* unlayered rules, which is why the unlayered `widget.css` `.lm-mcp-install__tab[aria-selected="true"]` was beating us on the tabs even after the panel fix landed). Docstring expanded to call out the normal-vs-`!important` asymmetry so the next editor doesn't repeat the trap.
- **`docs/_widgets/mcp-install/widget.js`**: Drop `updatePanels()`. Move the `<html data-mcp-install-*>` writes out of the `if (opts.persist)` branch in `select()` so html-attrs sync on every selection (`applySavedState`, `onBroadcast`, `onClick`, keyboard nav). For the click-before-saved-state case (user clicks a method tab with no client ever selected), `select()` now infers the other kind from `selectedValue(widget, otherKind)` and writes both attrs — `_panel_active` always has both attrs available to match.

### First-paint resource hints

- **`docs/conf.py`**: Extend `sphinx_font_preload` past gp-sphinx's defaults (Sans 400/700 + Mono 400) with Sans 500, Sans 600, and Sans 400 italic. Imported `DEFAULT_SPHINX_FONT_PRELOAD` so future upstream additions propagate without manual sync.
- **`docs/_templates/page.html`** *(new)*: Override `gp-furo-theme`'s `logo_prefetch_links` Jinja block to emit `<link rel="preload">` instead of `rel="prefetch"`. Also dedupes when `light_logo == dark_logo` (libtmux-mcp uses the same SVG for both).

### Documentation

- **`CHANGES`**: One `### Documentation` entry under `0.1.x (unreleased)` describing the cascade-layer fix and its cause (Tailwind preflight + Cascade Level 5 importance reversal).

## Design decisions

- **`@layer` over class-based `[hidden]` opt-in**: Considered swapping the panel template's `[hidden]` for a custom class to sidestep the Tailwind preflight entirely. Rejected because the `@layer` fix is one mechanical line and `[hidden]` is the canonical accessibility primitive for tab panels.
- **`updatePanels()` removed, not preserved as a no-op**: After the layer fix, `updatePanels()`'s DOM mutation is dead code — server-rendered `[hidden]` plus html data-attrs is sufficient. Keeping the function as a no-op would only invite a future contributor to "fix" it back to mutating panels and re-introduce the original flash vector.
- **Preload list scoped to demonstrably-needed weights**: Sans 500/600 normal cover headings and sidebar labels; Sans 400 italic covers the announcement bar `<em>`. Sans 300 / Mono 500–700 / italics other than 400 stay lazy because they're either not used above-the-fold or extremely rare. Preloading bytes the page never paints contends with critical-path resources.
- **Logo override stays local, not pushed upstream into `gp-furo-theme`**: The fix isn't libtmux-mcp-specific — every `gp-furo` consumer with a logo gets the delayed paint. But shipping the upstream PR is a separate effort; the local override unblocks this branch now.

## Verification

After build, verify the prehydrate snippet ships in `<head>` wrapped in the new layer:

```sh
grep -c '@layer mcp-install-prehydrate' docs/_build/index.html
```

Verify the logo is preloaded and no longer prefetched:

```sh
grep -c 'rel="prefetch"[^>]*libtmux\.svg' docs/_build/index.html
```

```sh
grep -c 'rel="preload"[^>]*libtmux\.svg' docs/_build/index.html
```

Verify the font preloads include 500, 600, and 400 italic:

```sh
grep -oE 'rel="preload"[^>]*woff2[^>]*' docs/_build/index.html
```

Reproduce the original shift in the browser to confirm CLS = 0:

```js
localStorage.setItem("libtmux-mcp.mcp-install.client", "cursor");
localStorage.setItem("libtmux-mcp.mcp-install.method", "pip");
location.reload();
```

```js
const shifts = [];
new PerformanceObserver((list) => {
  for (const e of list.getEntries()) if (!e.hadRecentInput) shifts.push(e.value);
}).observe({ type: "layout-shift", buffered: true });
setTimeout(() => console.log("CLS:", shifts.reduce((a, b) => a + b, 0)), 3000);
```

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` — lint clean
- [x] `uv run ruff format .` — formatting unchanged
- [x] `uv run mypy` — types clean
- [x] `uv run py.test --reruns 0 -vvv` — full suite passes (no flake retry)
- [x] `just build-docs` — docs build succeeds with no new warnings
- [x] CLS = 0 with `(cursor, pip)` saved state (worst case: 363 px tall pip panel)
- [x] CLS = 0 with `(claude-code, pip)` saved state
- [x] CLS = 0 with cleared `localStorage` (default `(claude-code, uvx)` paints)
- [x] Active-tab indicator paints on saved tabs at first frame, never on server default
- [x] Click `pip → uvx → pip` cycle updates the visible panel correctly
- [x] Click a method tab with no client ever clicked — inferred client + new method both write to `<html>`, `_panel_active` matches
- [x] Sidebar logo SVG fetches at t≈11 ms (was lazy on `<img>` first encounter), arrives before first-contentful-paint
- [x] Sans 500 / 600 normal and Sans 400 italic fetch parallel with the rest of the preload trio at t=11 ms; FontFace API reports `loaded` before first paint
- [x] Announcement `<em>Pre-alpha.</em>` paints italic on the very first frame; no plain-roman → italic swap
