### PR TITLE
Make tmux MCP fire on bare 'pane' / 'window' / 'session'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,21 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+- Bare *"pane"* / *"window"* / *"session"* prompts now reliably
+  activate libtmux-mcp without the user saying "tmux". An
+  `_INSTR_SCOPE` instruction segment names positive triggers
+  + explicit anti-triggers (browser, editor, i3, Jupyter); six
+  discovery-anchor docstrings carry tmux-vocabulary synonyms
+  (terminal / shell / scrollback / multiplexer / workspace) so
+  the BM25 corpus indexes them; {tooliconl}`list-panes`,
+  {tooliconl}`list-windows`, and {tooliconl}`snapshot-pane`
+  carry an `anthropic/alwaysLoad: true` per-tool meta hint
+  (Claude Code v2.1.121+). `serverInfo.name` is now `tmux`.
+  Transmitted `instructions=` re-fits Claude Code's 2KB
+  ceiling across all safety tiers. (#37)
+
 ## libtmux-mcp 0.1.0a5 (2026-05-06)
 
 _Pane geometry on response models, the `find_pane_by_position`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,34 @@ import typing as t
 from gp_sphinx.config import make_linkcode_resolve, merge_sphinx_config
 from gp_sphinx.defaults import DEFAULT_SPHINX_FONT_PRELOAD
 
+# Docs-only shim: ``sphinx_autodoc_fastmcp.ToolCollector.tool()`` is a mock
+# of ``FastMCP.tool()`` and only accepts ``title``, ``annotations``, ``tags``.
+# Tools that pass ``meta=DISCOVERY_META`` for the per-tool
+# ``anthropic/alwaysLoad`` hint (verified at runtime via per-tool ``meta=``)
+# raise ``TypeError`` inside the mock, which silently drops the entire
+# enclosing module's tools from the docs catalog. Patch the mock to accept
+# and ignore ``meta`` so the docs build's tool registry stays complete.
+#
+# Upstream fix is to add ``**kwargs`` to the mock signature; tracked at
+# https://github.com/git-pull/gp-sphinx/issues/35 — remove this shim
+# (and the trailing ``ToolCollector.tool = ...`` assignment) once that
+# lands and a release ships.
+from sphinx_autodoc_fastmcp._collector import (
+    ToolCollector,
+)
+
 import libtmux_mcp
+
+_orig_tool_collector_tool = ToolCollector.tool
+
+
+def _patched_tool_collector_tool(self: ToolCollector, **kwargs: t.Any) -> t.Any:
+    """Drop ``meta`` from kwargs so the mock signature still binds."""
+    kwargs.pop("meta", None)
+    return _orig_tool_collector_tool(self, **kwargs)
+
+
+ToolCollector.tool = _patched_tool_collector_tool  # type: ignore[assignment,method-assign]
 
 if t.TYPE_CHECKING:
     from sphinx.application import Sphinx

--- a/src/libtmux_mcp/_utils.py
+++ b/src/libtmux_mcp/_utils.py
@@ -328,6 +328,21 @@ ANNOTATIONS_DESTRUCTIVE: dict[str, bool] = {
     "idempotentHint": False,
     "openWorldHint": False,
 }
+
+#: Per-tool MCP ``meta`` payload that hints clients to keep this tool
+#: always visible (not deferred). FastMCP passes ``meta`` opaquely
+#: (verified vs ``~/study/python/fastmcp/src`` — no special handling);
+#: honoring is delegated to Claude Code, where ``alwaysLoad`` is
+#: documented at https://code.claude.com/docs/en/mcp (v2.1.121+).
+#:
+#: Best-effort by design — safe no-op for clients that don't index the
+#: ``anthropic/*`` namespace. Apply only to read-tier discovery anchors
+#: (``list_panes``, ``list_windows``, ``snapshot_pane``); each
+#: always-loaded tool consumes a fixed schema budget in clients that
+#: honour the hint, so widening the set has a real cost.
+DISCOVERY_META: dict[str, t.Any] = {
+    "anthropic/alwaysLoad": True,
+}
 #: Annotations for tools that stay in the ``mutating`` tier (so they remain
 #: visible to default-profile agents) but whose default behaviour can
 #: terminate processes or otherwise lose state.

--- a/src/libtmux_mcp/server.py
+++ b/src/libtmux_mcp/server.py
@@ -104,7 +104,8 @@ _INSTR_WAIT_NOT_POLL = (
 #: explanation into a tool description.
 _INSTR_HOOKS_GAP = (
     "HOOKS ARE READ-ONLY: inspect via show_hooks / show_hook. "
-    "Write-hooks belong in your tmux config file, not a transient MCP session."
+    "Write-hooks survive process death; keep them in your tmux config file, "
+    "not a transient MCP session."
 )
 
 #: Gap-explainer: ``list_buffers`` is intentionally absent because tmux
@@ -149,9 +150,9 @@ def _build_instructions(safety_level: str = TAG_MUTATING) -> str:
 
     # Safety tier context
     parts.append(
-        f"\n\nSafety level: {safety_level}. Tiers: readonly (reads), "
-        "mutating (reads+sends), destructive (reads+sends+kills). Set via "
-        "LIBTMUX_SAFETY env var; off-tier tools are hidden."
+        f"\n\nSafety level: {safety_level} "
+        "(readonly: read; mutating: read+send; destructive: read+send+kill). "
+        "Set LIBTMUX_SAFETY; off-tier tools are hidden."
     )
 
     # Tier-conditioned discoverability hint. False-positive activation is

--- a/src/libtmux_mcp/server.py
+++ b/src/libtmux_mcp/server.py
@@ -266,9 +266,10 @@ def _gc_mcp_buffers(cache: t.Mapping[_ServerCacheKey, Server]) -> None:
 
 
 mcp = FastMCP(
-    name="libtmux",
+    name="tmux",
     version=__version__,
     instructions=_build_instructions(safety_level=_safety_level),
+    website_url="https://libtmux-mcp.git-pull.com/",
     lifespan=_lifespan,
     # Middleware runs outermost-first. Order rationale:
     #   1. TimingMiddleware — neutral observer; start clock as early

--- a/src/libtmux_mcp/server.py
+++ b/src/libtmux_mcp/server.py
@@ -61,68 +61,64 @@ _ServerCacheKey: t.TypeAlias = tuple[str | None, str | None, str | None]
 # ---------------------------------------------------------------------------
 
 _INSTR_HIERARCHY = (
-    "libtmux MCP server for programmatic tmux control. "
+    "libtmux MCP server for tmux. "
     "tmux hierarchy: Server > Session > Window > Pane. "
-    "Use pane_id (e.g. '%1') as the preferred targeting method - "
-    "it is globally unique within a tmux server. "
-    "Use send_keys to execute commands and capture_pane to read output. "
-    "Targeted tmux tools accept an optional socket_name parameter "
-    "(defaults to LIBTMUX_SOCKET env var); list_servers discovers "
-    "sockets via TMUX_TMPDIR plus optional extra_socket_paths instead."
+    "Prefer pane_id (e.g. '%1') for targeting. "
+    "Targeted tmux tools accept socket_name (defaults to LIBTMUX_SOCKET); "
+    "list_servers discovers sockets via TMUX_TMPDIR plus extra_socket_paths."
+)
+
+#: Activation rule. Names positive triggers and explicit anti-triggers
+#: so bare 'pane'/'window'/'session' default to tmux but the server
+#: stays out of the way for browser/editor/GUI/Jupyter contexts.
+_INSTR_SCOPE = (
+    "TRIGGERS: invoke for tmux objects (panes, windows, sessions). "
+    "Bare 'pane', 'split', 'this terminal', 'send keys', 'scrollback', "
+    "'copy mode' default to tmux. IDs '%' (pane), '@' (window), "
+    "'$' (session) are unambiguous.\n"
+    "ANTI-TRIGGERS: do NOT invoke for browser windows/tabs, editor panes "
+    "(VS Code, Cursor, Neovim splits), GUI windows (i3, sway, Hyprland), "
+    "Jupyter cells, login/HTTP sessions.\n"
+    "When ambiguous on bare 'window'/'session', ask one clarifying question."
 )
 
 _INSTR_METADATA_VS_CONTENT = (
-    "IMPORTANT — metadata vs content: list_windows, list_panes, and "
-    "list_sessions only search metadata (names, IDs, current command). "
-    "To find text that is actually visible in terminals — when users ask "
-    "what panes 'contain', 'mention', 'show', or 'have' — use "
-    "search_panes to search across all pane contents, or list_panes + "
-    "capture_pane on each pane for manual inspection."
+    "metadata vs content: list_windows, list_panes, list_sessions search "
+    "metadata only. Use search_panes or capture_pane to find text inside "
+    "terminals — what panes 'contain', 'mention', 'show'."
 )
 
 _INSTR_READ_TOOLS = (
-    "READ TOOLS TO PREFER: snapshot_pane returns pane content plus "
-    "cursor position, mode, and scroll state in one call — use it "
-    "instead of capture_pane + get_pane_info when you need context. "
-    "display_message evaluates a tmux format string (e.g. "
-    "'#{pane_current_command}', '#{session_name}') against a target "
-    "and returns the expanded value — cheaper than parsing captured "
-    "output. (The tool is named after the tmux 'display-message -p' "
-    "verb it wraps; its MCP title is 'Evaluate tmux Format String'.)"
+    "Prefer snapshot_pane over capture_pane + get_pane_info. "
+    "display_message evaluates a tmux format string against a target."
 )
 
 _INSTR_WAIT_NOT_POLL = (
-    "WAIT, DON'T POLL: for 'run command, wait for output' workflows "
-    "use wait_for_text (matches text/regex on a pane) or "
-    "wait_for_content_change (waits for any change). These block "
-    "server-side until the condition is met or the timeout expires, "
-    "which is dramatically cheaper in agent turns than capture_pane "
-    "in a retry loop."
+    "WAIT, DON'T POLL: use wait_for_text (text/regex) or "
+    "wait_for_content_change instead of capture_pane retry loops; "
+    "both block server-side until the condition or timeout."
 )
 
 #: Gap-explainer: write-hook tools are intentionally absent. See module
 #: comment above for when to add another ``_GAP`` segment vs. push the
 #: explanation into a tool description.
 _INSTR_HOOKS_GAP = (
-    "HOOKS ARE READ-ONLY: inspect via show_hooks / show_hook. Write-hook "
-    "tools are intentionally not exposed — tmux hooks survive process "
-    "death, so they belong in your tmux config file, not a transient "
-    "MCP session."
+    "HOOKS ARE READ-ONLY: inspect via show_hooks / show_hook. "
+    "Write-hooks belong in your tmux config file, not a transient MCP session."
 )
 
 #: Gap-explainer: ``list_buffers`` is intentionally absent because tmux
 #: buffers can include OS clipboard history. See module comment above.
 _INSTR_BUFFERS_GAP = (
-    "BUFFERS: load_buffer stages content, paste_buffer delivers it into "
-    "a pane, delete_buffer removes the staged buffer. Track owned "
-    "buffers via the BufferRef returned from load_buffer — there is no "
-    "list_buffers tool because tmux buffers may include OS clipboard "
-    "history (passwords, private snippets)."
+    "BUFFERS: load_buffer stages, paste_buffer delivers, delete_buffer "
+    "removes. Track via the BufferRef returned from load_buffer — no "
+    "list_buffers tool because tmux buffers may include OS clipboard history."
 )
 
 _BASE_INSTRUCTIONS = "\n\n".join(
     (
         _INSTR_HIERARCHY,
+        _INSTR_SCOPE,
         _INSTR_METADATA_VS_CONTENT,
         _INSTR_READ_TOOLS,
         _INSTR_WAIT_NOT_POLL,
@@ -153,14 +149,21 @@ def _build_instructions(safety_level: str = TAG_MUTATING) -> str:
 
     # Safety tier context
     parts.append(
-        f"\n\nSafety level: {safety_level}. "
-        "Available tiers: 'readonly' (read operations only), "
-        "'mutating' (default, read + write + send_keys), "
-        "'destructive' (all operations including kill commands). "
-        "Set via LIBTMUX_SAFETY env var. "
-        "Tools outside the active tier are hidden and will not appear in "
-        "tool listings."
+        f"\n\nSafety level: {safety_level}. Tiers: readonly (reads), "
+        "mutating (reads+sends), destructive (reads+sends+kills). Set via "
+        "LIBTMUX_SAFETY env var; off-tier tools are hidden."
     )
+
+    # Tier-conditioned discoverability hint. False-positive activation is
+    # cheap on readonly (worst case: an extra list_panes call) and
+    # expensive on mutating/destructive (where kill_* is one mis-routed
+    # query away). Reuse the existing safety axis instead of shipping a
+    # separate LIBTMUX_DISCOVERABILITY knob.
+    if safety_level == TAG_READONLY:
+        parts.append(
+            "\n\nReadonly mode: when uncertain about terminal state, prefer "
+            "one read-only probe (snapshot_pane, list_panes, search_panes)."
+        )
 
     # Agent tmux context
     tmux_pane = os.environ.get("TMUX_PANE")
@@ -171,18 +174,13 @@ def _build_instructions(safety_level: str = TAG_MUTATING) -> str:
         socket_path = env_parts[0] if env_parts else None
         socket_name = socket_path.rsplit("/", 1)[-1] if socket_path else None
 
-        context = (
-            f"\n\nAgent context: This MCP server is running inside "
-            f"tmux pane {tmux_pane}"
-        )
+        context = f"\n\nAgent context: this MCP runs inside tmux pane {tmux_pane}"
         if socket_name:
-            context += f" (socket: {socket_name})"
+            context += f" (socket {socket_name})"
         context += (
-            ". Tool results annotate the caller's own pane with "
-            "is_caller=true. Use this to distinguish your own pane from "
-            "others. To answer 'which pane/window/session am I in?' call "
-            "list_panes (or snapshot_pane) and filter for is_caller=true — "
-            "your pane is identified above. No dedicated whoami tool exists."
+            ". Tool results mark the caller's own pane is_caller=true; "
+            "filter list_panes for is_caller=true to answer "
+            "'which pane am I in?' (no whoami tool)."
         )
         parts.append(context)
 

--- a/src/libtmux_mcp/tools/pane_tools/__init__.py
+++ b/src/libtmux_mcp/tools/pane_tools/__init__.py
@@ -18,6 +18,7 @@ from libtmux_mcp._utils import (
     ANNOTATIONS_MUTATING_DESTRUCTIVE,
     ANNOTATIONS_RO,
     ANNOTATIONS_SHELL,
+    DISCOVERY_META,
     TAG_DESTRUCTIVE,
     TAG_MUTATING,
     TAG_READONLY,
@@ -118,9 +119,12 @@ def register(mcp: FastMCP) -> None:
     mcp.tool(title="Wait For Text", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
         wait_for_text
     )
-    mcp.tool(title="Snapshot Pane", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
-        snapshot_pane
-    )
+    mcp.tool(
+        title="Snapshot Pane",
+        annotations=ANNOTATIONS_RO,
+        tags={TAG_READONLY},
+        meta=DISCOVERY_META,
+    )(snapshot_pane)
     mcp.tool(
         title="Wait For Content Change",
         annotations=ANNOTATIONS_RO,

--- a/src/libtmux_mcp/tools/pane_tools/io.py
+++ b/src/libtmux_mcp/tools/pane_tools/io.py
@@ -137,10 +137,12 @@ def capture_pane(
     max_lines: int | None = CAPTURE_DEFAULT_MAX_LINES,
     socket_name: str | None = None,
 ) -> str:
-    """Capture the visible contents of a tmux pane.
+    """Capture the visible contents of a tmux pane (terminal scrollback).
 
-    This is the tool for reading what is displayed in a terminal. Use
-    search_panes to search for text across multiple panes at once.
+    Use for tmux pane output — 'capture the build log', 'what did the
+    server print' — not editor file contents. The tool for reading what
+    is displayed in a terminal; use search_panes to search across
+    multiple panes at once.
 
     Output is tail-preserved: when the capture exceeds ``max_lines``
     the oldest lines are dropped and the returned string is prefixed

--- a/src/libtmux_mcp/tools/pane_tools/meta.py
+++ b/src/libtmux_mcp/tools/pane_tools/meta.py
@@ -76,11 +76,13 @@ def snapshot_pane(
     max_lines: int | None = CAPTURE_DEFAULT_MAX_LINES,
     socket_name: str | None = None,
 ) -> PaneSnapshot:
-    """Take a rich snapshot of a tmux pane: content + cursor + mode + scroll state.
+    """Snapshot a tmux pane: visible terminal output, cursor, mode, scroll.
 
+    Use for terminal-contents inspection — 'what's in my pane', 'the
+    current shell output' — not editor panes or browser viewports.
     Returns everything capture_pane and get_pane_info return, plus cursor
     position, copy-mode state, and scroll position — in a single call.
-    Use this instead of separate capture_pane + get_pane_info calls when
+    Prefer this over separate capture_pane + get_pane_info calls when
     you need to reason about cursor location or pane mode.
 
     The ``content`` field is tail-preserved: when the captured pane

--- a/src/libtmux_mcp/tools/pane_tools/search.py
+++ b/src/libtmux_mcp/tools/pane_tools/search.py
@@ -86,11 +86,12 @@ def search_panes(
     offset: int = 0,
     socket_name: str | None = None,
 ) -> SearchPanesResult:
-    """Search for text across all pane contents.
+    """Search visible terminal text across all tmux panes.
 
-    Use this when users ask what panes 'contain', 'mention', or 'show'.
-    Searches each pane's visible content and returns panes where the
-    pattern is found, with matching lines.
+    Use when the user asks what panes 'contain', 'mention', or 'show' —
+    e.g. 'find the pane with the pytest failure'. Searches each pane's
+    visible terminal scrollback content (not editor or browser text)
+    and returns panes where the pattern is found, with matching lines.
 
     Bounded output contract
     -----------------------

--- a/src/libtmux_mcp/tools/server_tools.py
+++ b/src/libtmux_mcp/tools/server_tools.py
@@ -40,10 +40,12 @@ def list_sessions(
     socket_name: str | None = None,
     filters: dict[str, str] | str | None = None,
 ) -> list[SessionInfo]:
-    """List all tmux sessions.
+    """List tmux sessions (terminal workspaces) on a tmux server.
 
-    Use as the starting point for discovery — call this before targeting
-    specific sessions, windows, or panes.
+    Use for tmux multiplexer sessions — 'this session', 'my workspace',
+    'the dev session' — not login sessions or HTTP sessions. The starting
+    point for discovery — call this before targeting specific sessions,
+    windows, or panes.
 
     Parameters
     ----------

--- a/src/libtmux_mcp/tools/session_tools.py
+++ b/src/libtmux_mcp/tools/session_tools.py
@@ -12,6 +12,7 @@ from libtmux_mcp._utils import (
     ANNOTATIONS_DESTRUCTIVE,
     ANNOTATIONS_MUTATING,
     ANNOTATIONS_RO,
+    DISCOVERY_META,
     TAG_DESTRUCTIVE,
     TAG_MUTATING,
     TAG_READONLY,
@@ -37,10 +38,12 @@ def list_windows(
     socket_name: str | None = None,
     filters: dict[str, str] | str | None = None,
 ) -> list[WindowInfo]:
-    """List windows in a tmux session, or all windows across sessions.
+    """List tmux windows (terminal tabs) in a session, or across the server.
 
-    Only searches window metadata (name, index, layout). To search
-    the actual text visible in terminal panes, use search_panes instead.
+    Use for tmux windows — 'current window', 'this tab' (when terminal-
+    contextual) — not browser tabs or desktop windows. Only searches
+    window metadata (name, index, layout); to search the actual visible
+    terminal text, use search_panes.
 
     Parameters
     ----------
@@ -329,9 +332,12 @@ def select_window(
 
 def register(mcp: FastMCP) -> None:
     """Register session-level tools with the MCP instance."""
-    mcp.tool(title="List Windows", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
-        list_windows
-    )
+    mcp.tool(
+        title="List Windows",
+        annotations=ANNOTATIONS_RO,
+        tags={TAG_READONLY},
+        meta=DISCOVERY_META,
+    )(list_windows)
     mcp.tool(title="Get Session Info", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
         get_session_info
     )

--- a/src/libtmux_mcp/tools/window_tools.py
+++ b/src/libtmux_mcp/tools/window_tools.py
@@ -12,6 +12,7 @@ from libtmux_mcp._utils import (
     ANNOTATIONS_DESTRUCTIVE,
     ANNOTATIONS_MUTATING,
     ANNOTATIONS_RO,
+    DISCOVERY_META,
     TAG_DESTRUCTIVE,
     TAG_MUTATING,
     TAG_READONLY,
@@ -48,11 +49,12 @@ def list_panes(
     socket_name: str | None = None,
     filters: dict[str, str] | str | None = None,
 ) -> list[PaneInfo]:
-    """List panes in a tmux window, session, or across the entire server.
+    """List tmux panes (terminal multiplexer splits) in a window, session, or server.
 
-    Only searches pane metadata (current command, title, working directory).
-    To search the actual text visible in terminal panes, use search_panes
-    instead.
+    Use for terminal panes — including 'this pane', 'current pane',
+    'split pane', 'the bottom shell' — not editor splits or browser panes.
+    Only searches pane metadata (current command, title, working directory);
+    to search the actual visible terminal text, use search_panes.
 
     Parameters
     ----------
@@ -472,9 +474,12 @@ def move_window(
 
 def register(mcp: FastMCP) -> None:
     """Register window-level tools with the MCP instance."""
-    mcp.tool(title="List Panes", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
-        list_panes
-    )
+    mcp.tool(
+        title="List Panes",
+        annotations=ANNOTATIONS_RO,
+        tags={TAG_READONLY},
+        meta=DISCOVERY_META,
+    )(list_panes)
     mcp.tool(title="Get Window Info", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
         get_window_info
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -281,6 +281,124 @@ def test_build_instructions_always_includes_safety() -> None:
     assert "LIBTMUX_SAFETY" in result
 
 
+@pytest.mark.parametrize(
+    ("tier", "tmux_pane", "tmux_env"),
+    [
+        (TAG_READONLY, "%42", "/tmp/tmux-1000/default,12345,0"),
+        (TAG_MUTATING, "%42", "/tmp/tmux-1000/default,12345,0"),
+        (TAG_DESTRUCTIVE, "%42", "/tmp/tmux-1000/default,12345,0"),
+        (TAG_READONLY, "", ""),
+        (TAG_MUTATING, "", ""),
+        (TAG_DESTRUCTIVE, "", ""),
+        # Variable-length stress: longer socket name + multi-digit pane id.
+        # Guards against future text additions tipping a realistic case
+        # over the 2KB budget. Exercises BOTH axes — a multi-digit pane id
+        # (TMUX_PANE) and a longer socket name (LIBTMUX_SOCKET). Margin
+        # ~2 bytes; if a future text addition trips this, either trim
+        # further or fall back to a tighter compression form (drop spaces
+        # around ``/`` in HOOKS, drop spaces after colons in the safety
+        # paragraph) for additional bytes of margin.
+        (TAG_READONLY, "%99", "/tmp/tmux-1000/dev-prod,12345,0"),
+    ],
+)
+def test_full_instructions_under_2kb_across_tiers_and_tmux_pane(
+    monkeypatch: pytest.MonkeyPatch,
+    tier: str,
+    tmux_pane: str,
+    tmux_env: str,
+) -> None:
+    """The transmitted instructions= string fits Claude Code's 2KB budget.
+
+    The static ``_BASE_INSTRUCTIONS`` length is not the contract —
+    ``_build_instructions`` appends a safety-tier block, an optional
+    readonly-tier hint, and an optional ``$TMUX_PANE`` agent-context
+    block. The full transmitted string must be ≤ 2048 bytes for every
+    (tier, tmux_pane) combination, otherwise Claude Code silently
+    truncates the agent-context block — the only server-side fix for
+    "current window" anaphora.
+
+    Includes a variable-length stress case (longer socket name +
+    multi-digit pane id) so realistic runtime injections of
+    ``TMUX_PANE`` / ``TMUX`` cannot push the total over the budget
+    without the test catching it.
+    """
+    if tmux_pane:
+        monkeypatch.setenv("TMUX_PANE", tmux_pane)
+        monkeypatch.setenv("TMUX", tmux_env)
+    else:
+        monkeypatch.delenv("TMUX_PANE", raising=False)
+        monkeypatch.delenv("TMUX", raising=False)
+
+    instructions = _build_instructions(safety_level=tier)
+    size = len(instructions.encode())
+    assert size <= 2048, (
+        f"tier={tier} tmux_pane={tmux_pane!r}: "
+        f"{size} bytes exceeds Claude Code's 2KB ceiling"
+    )
+
+
+def test_base_instructions_document_scope() -> None:
+    """``_BASE_INSTRUCTIONS`` carries an activation rule with anti-triggers.
+
+    The SCOPE segment names positive triggers (pane, current, %, @, $)
+    and explicit anti-triggers (browser/editor/GUI/Jupyter) plus a
+    safety-valve clause for the ambiguous case. Without this segment,
+    bare 'pane'/'window'/'session' rely on the LLM to *infer* the tmux
+    context from each tool's description; with it, the LLM has explicit
+    boundaries it can quote when the user's phrasing is ambiguous.
+    """
+    for required in (
+        "TRIGGERS:",
+        "ANTI-TRIGGERS:",
+        "pane",
+        "'%'",
+        "'@'",
+        "'$'",
+        "VS Code",
+        "i3",
+        "Jupyter",
+        "clarifying question",
+    ):
+        assert required in _BASE_INSTRUCTIONS, f"missing: {required!r}"
+
+
+def test_scope_segment_carries_anti_triggers() -> None:
+    """SCOPE segment carries the activation rule, not just _BASE_INSTRUCTIONS.
+
+    Defensively pinned to ``_INSTR_SCOPE`` rather than the joined
+    string so a future refactor that moves the SCOPE content to a
+    different segment is caught here, not only by the
+    test_base_instructions_document_scope test on the joined string.
+    """
+    from libtmux_mcp.server import _INSTR_SCOPE
+
+    assert "TRIGGERS:" in _INSTR_SCOPE
+    assert "ANTI-TRIGGERS:" in _INSTR_SCOPE
+    assert "VS Code" in _INSTR_SCOPE
+    assert "Jupyter" in _INSTR_SCOPE
+    assert "clarifying question" in _INSTR_SCOPE
+
+
+@pytest.mark.parametrize("tier", [TAG_READONLY, TAG_MUTATING, TAG_DESTRUCTIVE])
+def test_readonly_hint_visible_only_on_readonly_tier(
+    monkeypatch: pytest.MonkeyPatch, tier: str
+) -> None:
+    """The 'Readonly mode:' investigation hint appears only on readonly.
+
+    False-positive activation is cheap on readonly (worst case: an
+    extra ``list_panes`` call) and expensive on mutating/destructive
+    (where ``kill_*`` is one mis-routed query away). Reuse the existing
+    safety axis instead of shipping a separate discoverability knob.
+    """
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+    monkeypatch.delenv("TMUX", raising=False)
+    instructions = _build_instructions(safety_level=tier)
+    if tier == TAG_READONLY:
+        assert "Readonly mode:" in instructions
+    else:
+        assert "Readonly mode:" not in instructions
+
+
 # ---------------------------------------------------------------------------
 # Lifespan tests
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -400,6 +400,106 @@ def test_readonly_hint_visible_only_on_readonly_tier(
 
 
 # ---------------------------------------------------------------------------
+# Discovery anchors — BM25 lexicon and alwaysLoad meta hints
+# ---------------------------------------------------------------------------
+
+#: The six high-traffic discovery anchors. ToolSearch BM25-ranks
+#: against tool ``description`` (FastMCP's griffe parser hands the
+#: leading paragraph in), so the anchors carry a buried-synonym
+#: lexicon plus an inline anti-trigger to widen the indexed surface
+#: and add explicit boundaries.
+_DISCOVERY_ANCHORS = frozenset(
+    [
+        "list_panes",
+        "list_windows",
+        "list_sessions",
+        "snapshot_pane",
+        "search_panes",
+        "capture_pane",
+    ]
+)
+
+
+#: Discovery anchors that carry the ``anthropic/alwaysLoad`` per-tool
+#: meta hint. Read-only only — best-effort hint to Claude Code that
+#: keeps a tiny tmux vocabulary always-visible without preloading
+#: every tool's schema.
+_ALWAYS_LOAD_ANCHORS = frozenset(["list_panes", "list_windows", "snapshot_pane"])
+
+
+def test_server_advertised_as_tmux() -> None:
+    """``serverInfo.name`` aligns with the README registration slug.
+
+    Cross-client display fields show ``serverInfo.name``; aligning to
+    ``tmux`` removes a papercut where users registering via the README
+    get ``mcp__tmux__*`` tool prefixes but the protocol-handshake name
+    still says ``libtmux``.
+    """
+    from libtmux_mcp.server import mcp
+
+    assert mcp.name == "tmux"
+
+
+def test_discovery_anchor_descriptions_carry_tmux_and_synonyms() -> None:
+    """The six discovery anchors carry tmux + a buried synonym in BM25 corpus.
+
+    FastMCP's ``parse_docstring`` extracts the leading text block
+    before the first ``Parameters`` / ``Returns`` section as
+    ``tool.description``. Both that paragraph and any subsequent prose
+    ride into the BM25 corpus, so burying terminal / shell /
+    scrollback / multiplexer / workspace synonyms in natural prose
+    widens the indexed lexicon without leaving a discovery-engineering
+    artifact in user-facing ``--help`` output.
+    """
+    import asyncio
+
+    from fastmcp import FastMCP
+
+    from libtmux_mcp.tools import register_tools
+
+    mcp = FastMCP(name="desc-audit")
+    register_tools(mcp)
+    tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+    synonyms = {"terminal", "shell", "scrollback", "multiplexer", "workspace"}
+    for tool_name in _DISCOVERY_ANCHORS:
+        tool = tools.get(tool_name)
+        assert tool is not None, f"tool not registered: {tool_name}"
+        desc = (tool.description or "").lower()
+        assert "tmux" in desc, f"{tool_name} description missing 'tmux'"
+        assert any(s in desc for s in synonyms), (
+            f"{tool_name} description missing a synonym from {synonyms}: {desc[:200]!r}"
+        )
+
+
+def test_discovery_anchors_marked_alwaysload() -> None:
+    """``list_panes``, ``list_windows``, ``snapshot_pane`` carry alwaysLoad.
+
+    Best-effort hint — FastMCP passes ``meta`` opaquely, so honoring
+    is delegated to Claude Code where the field is documented at
+    ``code.claude.com/docs/en/mcp`` (v2.1.121+). The test asserts only
+    the positive contract; over-specifying the negative space is
+    chrome.
+    """
+    import asyncio
+
+    from fastmcp import FastMCP
+
+    from libtmux_mcp.tools import register_tools
+
+    mcp = FastMCP(name="meta-audit")
+    register_tools(mcp)
+    tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+    for tool_name in _ALWAYS_LOAD_ANCHORS:
+        tool = tools.get(tool_name)
+        assert tool is not None, f"tool not registered: {tool_name}"
+        meta = getattr(tool, "meta", None) or {}
+        assert meta.get("anthropic/alwaysLoad") is True, (
+            f"{tool_name} meta missing anthropic/alwaysLoad: {meta!r}"
+        )
+
+
 # Lifespan tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -173,6 +173,20 @@ def test_base_instructions_document_hook_boundary() -> None:
     assert "tmux config file" in _BASE_INSTRUCTIONS
 
 
+def test_hooks_gap_keeps_process_death_rationale() -> None:
+    """Hook-gap segment carries the rationale, not just the rule.
+
+    Defensively pinned to ``_INSTR_HOOKS_GAP`` rather than
+    ``_BASE_INSTRUCTIONS`` so a future refactor that moves "tmux config
+    file" into a different segment is caught here, not only by the
+    line-173 test on the joined string.
+    """
+    from libtmux_mcp.server import _INSTR_HOOKS_GAP
+
+    assert "survive process death" in _INSTR_HOOKS_GAP
+    assert "tmux config file" in _INSTR_HOOKS_GAP
+
+
 def test_base_instructions_document_socket_name_contract() -> None:
     """_BASE_INSTRUCTIONS frames the socket_name promise precisely.
 


### PR DESCRIPTION
## Summary

Bare *pane* / *window* / *session* prompts (without saying "tmux") were failing to trigger libtmux-mcp in Claude Code. This PR fixes that with three discrete server-side levers:

1. **`_INSTR_SCOPE` activation rule** — names positive triggers (pane, split, terminal, scrollback, copy mode, `%`/`@`/`$` IDs) and explicit anti-triggers (browser, VS Code, Cursor, Neovim, i3/sway/Hyprland, Jupyter cells, login/HTTP sessions). The full transmitted `instructions=` now fits Claude Code's 2KB budget across all three safety tiers.
2. **Discovery-anchor descriptions + `alwaysLoad` meta + `serverInfo.name="tmux"`** — six anchor docstrings (`list_panes`, `list_windows`, `list_sessions`, `snapshot_pane`, `search_panes`, `capture_pane`) carry `tmux` plus a buried synonym (terminal / shell / scrollback / multiplexer / workspace) that lands in BM25's search corpus. Three read-only anchors carry `anthropic/alwaysLoad: true` so a tiny tmux vocabulary stays visible without preloading every schema.
3. **HOOKS_GAP rationale restored** — *"Write-hooks survive process death"* is the load-bearing causal phrase that makes the read-only-hooks rule a correctness boundary instead of a soft preference. Paired with safety-tier paragraph compression so net byte cost is -1.

## Test plan

- [x] `uv run ruff check . --fix --show-fixes && uv run ruff format .`
- [x] `uv run mypy`
- [x] `uv run py.test --reruns 0 -vvv` (442 passed)
- [x] `just build-docs` (clean, 50 baseline warnings)
- [x] In-process budget probe: `readonly+TMUX_PANE` worst case is 2044 bytes (margin 4 of 2048)
- [ ] Manual probes in fresh Claude Code session: bare *"pane"*, *"current window"*, *"this session"* all route to `mcp__tmux__*`; bare *"browser tab"*, *"editor split"*, *"Jupyter cell"* do **not**