### PR TITLE
Tag hierarchy-noun tool titles with "tmux"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,19 @@ _Notes on upcoming releases will be added here_
   Transmitted `instructions=` re-fits Claude Code's 2KB
   ceiling across all safety tiers. (#37)
 
+### Documentation
+
+- Hierarchy-noun tool titles gain a `tmux` qualifier (e.g.
+  *"List Sessions"* → *"List tmux Sessions"*) for display-time
+  disambiguation in catalog UIs and `claude mcp list`-style
+  outputs. Verbs-of-art ({tooliconl}`send-keys`,
+  {tooliconl}`pipe-pane`, {tooliconl}`snapshot-pane`,
+  {tooliconl}`capture-pane`, {tooliconl}`paste-text`) stay
+  generic — already tmux-specific terms; over-prefixing reads
+  as visual chrome. Title is NOT in BM25's search corpus
+  (verified vs FastMCP's `_extract_searchable_text`); this is
+  pure catalog polish, no activation impact. (#38)
+
 ## libtmux-mcp 0.1.0a5 (2026-05-06)
 
 _Pane geometry on response models, the `find_pane_by_position`

--- a/src/libtmux_mcp/tools/buffer_tools.py
+++ b/src/libtmux_mcp/tools/buffer_tools.py
@@ -384,19 +384,19 @@ def register(mcp: FastMCP) -> None:
     into a shell). Other buffer tools are plain mutating ops on the
     tmux buffer store.
     """
-    mcp.tool(title="Load Buffer", annotations=ANNOTATIONS_SHELL, tags={TAG_MUTATING})(
-        load_buffer
-    )
     mcp.tool(
-        title="Paste Buffer",
+        title="Load tmux Buffer", annotations=ANNOTATIONS_SHELL, tags={TAG_MUTATING}
+    )(load_buffer)
+    mcp.tool(
+        title="Paste tmux Buffer",
         annotations=ANNOTATIONS_SHELL,
         tags={TAG_MUTATING},
     )(paste_buffer)
-    mcp.tool(title="Show Buffer", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
+    mcp.tool(title="Show tmux Buffer", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
         show_buffer
     )
     mcp.tool(
-        title="Delete Buffer",
+        title="Delete tmux Buffer",
         annotations=ANNOTATIONS_MUTATING,
         tags={TAG_MUTATING},
     )(delete_buffer)

--- a/src/libtmux_mcp/tools/env_tools.py
+++ b/src/libtmux_mcp/tools/env_tools.py
@@ -118,9 +118,13 @@ def set_environment(
 
 def register(mcp: FastMCP) -> None:
     """Register environment tools with the MCP instance."""
-    mcp.tool(title="Show Environment", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
-        show_environment
-    )
     mcp.tool(
-        title="Set Environment", annotations=ANNOTATIONS_MUTATING, tags={TAG_MUTATING}
+        title="Show tmux Environment",
+        annotations=ANNOTATIONS_RO,
+        tags={TAG_READONLY},
+    )(show_environment)
+    mcp.tool(
+        title="Set tmux Environment",
+        annotations=ANNOTATIONS_MUTATING,
+        tags={TAG_MUTATING},
     )(set_environment)

--- a/src/libtmux_mcp/tools/hook_tools.py
+++ b/src/libtmux_mcp/tools/hook_tools.py
@@ -259,9 +259,9 @@ def show_hook(
 
 def register(mcp: FastMCP) -> None:
     """Register read-only hook tools with the MCP instance."""
-    mcp.tool(title="Show Hooks", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
+    mcp.tool(title="Show tmux Hooks", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
         show_hooks
     )
-    mcp.tool(title="Show Hook", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
+    mcp.tool(title="Show tmux Hook", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
         show_hook
     )

--- a/src/libtmux_mcp/tools/option_tools.py
+++ b/src/libtmux_mcp/tools/option_tools.py
@@ -141,9 +141,9 @@ def set_option(
 
 def register(mcp: FastMCP) -> None:
     """Register option tools with the MCP instance."""
-    mcp.tool(title="Show Option", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
+    mcp.tool(title="Show tmux Option", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
         show_option
     )
-    mcp.tool(title="Set Option", annotations=ANNOTATIONS_MUTATING, tags={TAG_MUTATING})(
-        set_option
-    )
+    mcp.tool(
+        title="Set tmux Option", annotations=ANNOTATIONS_MUTATING, tags={TAG_MUTATING}
+    )(set_option)

--- a/src/libtmux_mcp/tools/server_tools.py
+++ b/src/libtmux_mcp/tools/server_tools.py
@@ -336,18 +336,22 @@ def list_servers(
 
 def register(mcp: FastMCP) -> None:
     """Register server-level tools with the MCP instance."""
-    mcp.tool(title="List Sessions", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
-        list_sessions
-    )
-    mcp.tool(title="List Servers", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
-        list_servers
-    )
     mcp.tool(
-        title="Create Session", annotations=ANNOTATIONS_CREATE, tags={TAG_MUTATING}
+        title="List tmux Sessions", annotations=ANNOTATIONS_RO, tags={TAG_READONLY}
+    )(list_sessions)
+    mcp.tool(
+        title="List tmux Servers", annotations=ANNOTATIONS_RO, tags={TAG_READONLY}
+    )(list_servers)
+    mcp.tool(
+        title="Create tmux Session",
+        annotations=ANNOTATIONS_CREATE,
+        tags={TAG_MUTATING},
     )(create_session)
     mcp.tool(
-        title="Kill Server", annotations=ANNOTATIONS_DESTRUCTIVE, tags={TAG_DESTRUCTIVE}
+        title="Kill tmux Server",
+        annotations=ANNOTATIONS_DESTRUCTIVE,
+        tags={TAG_DESTRUCTIVE},
     )(kill_server)
-    mcp.tool(title="Get Server Info", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
-        get_server_info
-    )
+    mcp.tool(
+        title="Get tmux Server Info", annotations=ANNOTATIONS_RO, tags={TAG_READONLY}
+    )(get_server_info)

--- a/src/libtmux_mcp/tools/session_tools.py
+++ b/src/libtmux_mcp/tools/session_tools.py
@@ -333,25 +333,29 @@ def select_window(
 def register(mcp: FastMCP) -> None:
     """Register session-level tools with the MCP instance."""
     mcp.tool(
-        title="List Windows",
+        title="List tmux Windows",
         annotations=ANNOTATIONS_RO,
         tags={TAG_READONLY},
         meta=DISCOVERY_META,
     )(list_windows)
-    mcp.tool(title="Get Session Info", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
-        get_session_info
-    )
     mcp.tool(
-        title="Create Window", annotations=ANNOTATIONS_CREATE, tags={TAG_MUTATING}
+        title="Get tmux Session Info", annotations=ANNOTATIONS_RO, tags={TAG_READONLY}
+    )(get_session_info)
+    mcp.tool(
+        title="Create tmux Window", annotations=ANNOTATIONS_CREATE, tags={TAG_MUTATING}
     )(create_window)
     mcp.tool(
-        title="Rename Session", annotations=ANNOTATIONS_MUTATING, tags={TAG_MUTATING}
+        title="Rename tmux Session",
+        annotations=ANNOTATIONS_MUTATING,
+        tags={TAG_MUTATING},
     )(rename_session)
     mcp.tool(
-        title="Kill Session",
+        title="Kill tmux Session",
         annotations=ANNOTATIONS_DESTRUCTIVE,
         tags={TAG_DESTRUCTIVE},
     )(kill_session)
     mcp.tool(
-        title="Select Window", annotations=ANNOTATIONS_MUTATING, tags={TAG_MUTATING}
+        title="Select tmux Window",
+        annotations=ANNOTATIONS_MUTATING,
+        tags={TAG_MUTATING},
     )(select_window)

--- a/src/libtmux_mcp/tools/wait_for_tools.py
+++ b/src/libtmux_mcp/tools/wait_for_tools.py
@@ -212,12 +212,12 @@ async def signal_channel(
 def register(mcp: FastMCP) -> None:
     """Register wait-for channel tools with the MCP instance."""
     mcp.tool(
-        title="Wait For Channel",
+        title="Wait For tmux Channel",
         annotations=ANNOTATIONS_MUTATING,
         tags={TAG_MUTATING},
     )(wait_for_channel)
     mcp.tool(
-        title="Signal Channel",
+        title="Signal tmux Channel",
         annotations=ANNOTATIONS_MUTATING,
         tags={TAG_MUTATING},
     )(signal_channel)

--- a/src/libtmux_mcp/tools/window_tools.py
+++ b/src/libtmux_mcp/tools/window_tools.py
@@ -475,31 +475,39 @@ def move_window(
 def register(mcp: FastMCP) -> None:
     """Register window-level tools with the MCP instance."""
     mcp.tool(
-        title="List Panes",
+        title="List tmux Panes",
         annotations=ANNOTATIONS_RO,
         tags={TAG_READONLY},
         meta=DISCOVERY_META,
     )(list_panes)
-    mcp.tool(title="Get Window Info", annotations=ANNOTATIONS_RO, tags={TAG_READONLY})(
-        get_window_info
-    )
-    mcp.tool(title="Split Window", annotations=ANNOTATIONS_CREATE, tags={TAG_MUTATING})(
-        split_window
-    )
     mcp.tool(
-        title="Rename Window", annotations=ANNOTATIONS_MUTATING, tags={TAG_MUTATING}
+        title="Get tmux Window Info", annotations=ANNOTATIONS_RO, tags={TAG_READONLY}
+    )(get_window_info)
+    mcp.tool(
+        title="Split tmux Window", annotations=ANNOTATIONS_CREATE, tags={TAG_MUTATING}
+    )(split_window)
+    mcp.tool(
+        title="Rename tmux Window",
+        annotations=ANNOTATIONS_MUTATING,
+        tags={TAG_MUTATING},
     )(rename_window)
     mcp.tool(
-        title="Kill Window",
+        title="Kill tmux Window",
         annotations=ANNOTATIONS_DESTRUCTIVE,
         tags={TAG_DESTRUCTIVE},
     )(kill_window)
     mcp.tool(
-        title="Select Layout", annotations=ANNOTATIONS_MUTATING, tags={TAG_MUTATING}
+        title="Select tmux Layout",
+        annotations=ANNOTATIONS_MUTATING,
+        tags={TAG_MUTATING},
     )(select_layout)
     mcp.tool(
-        title="Resize Window", annotations=ANNOTATIONS_MUTATING, tags={TAG_MUTATING}
+        title="Resize tmux Window",
+        annotations=ANNOTATIONS_MUTATING,
+        tags={TAG_MUTATING},
     )(resize_window)
     mcp.tool(
-        title="Move Window", annotations=ANNOTATIONS_MUTATING, tags={TAG_MUTATING}
+        title="Move tmux Window",
+        annotations=ANNOTATIONS_MUTATING,
+        tags={TAG_MUTATING},
     )(move_window)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -414,6 +414,67 @@ def test_readonly_hint_visible_only_on_readonly_tier(
 
 
 # ---------------------------------------------------------------------------
+# Tool title audit — display-time disambiguation contract
+# ---------------------------------------------------------------------------
+
+#: Tools whose title must include the word ``tmux``. Hierarchy nouns
+#: (window, session, server, option, environment, hook, buffer, channel)
+#: collide with browser / editor / WM / OS-channel domains; the qualifier
+#: is load-bearing for display surfaces (Claude Code's tool catalog UI,
+#: ``claude mcp list`` outputs). Title is NOT in BM25's search corpus
+#: (verified vs FastMCP's _extract_searchable_text), so this lever is
+#: purely human-readable disambiguation. ``display_message`` is included
+#: because its title was pre-qualified as "Evaluate tmux Format String"
+#: by an earlier rename — pinning it here guards against silent
+#: regression to "Evaluate Format String".
+_TMUX_QUALIFIED_TOOLS = frozenset(
+    [
+        # 5 server-level
+        "list_sessions",
+        "list_servers",
+        "create_session",
+        "kill_server",
+        "get_server_info",
+        # 6 session-level
+        "list_windows",
+        "get_session_info",
+        "create_window",
+        "rename_session",
+        "kill_session",
+        "select_window",
+        # 8 window-level
+        "list_panes",
+        "get_window_info",
+        "split_window",
+        "rename_window",
+        "kill_window",
+        "select_layout",
+        "resize_window",
+        "move_window",
+        # 2 option
+        "show_option",
+        "set_option",
+        # 2 env
+        "show_environment",
+        "set_environment",
+        # 2 hook
+        "show_hooks",
+        "show_hook",
+        # 4 buffer
+        "load_buffer",
+        "paste_buffer",
+        "show_buffer",
+        "delete_buffer",
+        # 2 wait_for channel
+        "wait_for_channel",
+        "signal_channel",
+        # 1 pre-qualified pane tool — see docstring above
+        "display_message",
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
 # Discovery anchors — BM25 lexicon and alwaysLoad meta hints
 # ---------------------------------------------------------------------------
 
@@ -439,6 +500,35 @@ _DISCOVERY_ANCHORS = frozenset(
 #: keeps a tiny tmux vocabulary always-visible without preloading
 #: every tool's schema.
 _ALWAYS_LOAD_ANCHORS = frozenset(["list_panes", "list_windows", "snapshot_pane"])
+
+
+#: Verbs-of-art whose titles stay generic — they are tmux-specific
+#: terms already and over-prefixing reads as visual chrome.
+#: ``display_message`` is exempt from this set (already qualified as
+#: "Evaluate tmux Format String"; pinned in _TMUX_QUALIFIED_TOOLS).
+_VERBS_OF_ART = frozenset(
+    [
+        "send_keys",
+        "capture_pane",
+        "snapshot_pane",
+        "paste_text",
+        "get_pane_info",
+        "find_pane_by_position",
+        "clear_pane",
+        "search_panes",
+        "wait_for_text",
+        "wait_for_content_change",
+        "select_pane",
+        "swap_pane",
+        "enter_copy_mode",
+        "exit_copy_mode",
+        "resize_pane",
+        "kill_pane",
+        "respawn_pane",
+        "set_pane_title",
+        "pipe_pane",
+    ]
+)
 
 
 def test_server_advertised_as_tmux() -> None:
@@ -514,6 +604,64 @@ def test_discovery_anchors_marked_alwaysload() -> None:
         )
 
 
+def test_hierarchy_tool_titles_carry_tmux_qualifier() -> None:
+    """Hierarchy-noun titles include 'tmux' for display disambiguation.
+
+    Without the qualifier, "List Windows" competes with browser /
+    editor / WM MCPs that share the noun. Title is NOT BM25-indexed
+    (FastMCP's _extract_searchable_text only concatenates name +
+    description + parameter names + parameter descriptions), so this
+    test guards the human-readable disambiguation contract for tool
+    catalog UIs and ``claude mcp list``-style outputs only.
+    """
+    import asyncio
+
+    from fastmcp import FastMCP
+
+    from libtmux_mcp.tools import register_tools
+
+    mcp = FastMCP(name="title-audit")
+    register_tools(mcp)
+    tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+    for tool_name in _TMUX_QUALIFIED_TOOLS:
+        tool = tools.get(tool_name)
+        assert tool is not None, f"tool not registered: {tool_name}"
+        assert tool.title is not None, f"{tool_name} missing title"
+        assert "tmux" in tool.title.lower(), (
+            f"{tool_name} title {tool.title!r} should include 'tmux'"
+        )
+
+
+def test_verbs_of_art_titles_unchanged() -> None:
+    """Verb-of-art titles stay generic — over-prefixing is visual chrome.
+
+    Send Keys, Pipe Pane, Snapshot Pane, Capture Pane, Paste Text,
+    etc. are tmux-specific terms already. Adding ``tmux`` to the title
+    delivers no display-disambiguation lift and inflates every tool
+    catalog entry.
+    """
+    import asyncio
+
+    from fastmcp import FastMCP
+
+    from libtmux_mcp.tools import register_tools
+
+    mcp = FastMCP(name="verbs-of-art-audit")
+    register_tools(mcp)
+    tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+    for tool_name in _VERBS_OF_ART:
+        tool = tools.get(tool_name)
+        assert tool is not None, f"tool not registered: {tool_name}"
+        assert tool.title is not None, f"{tool_name} missing title"
+        assert "tmux" not in tool.title.lower(), (
+            f"{tool_name} title {tool.title!r} should NOT include 'tmux' "
+            "— it's a verb-of-art, already disambiguated by the verb"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Lifespan tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

31 hierarchy-noun tool titles gain a `tmux` qualifier (e.g. *"List Sessions"* → *"List tmux Sessions"*) for display-time disambiguation in tool catalog UIs and `claude mcp list`-style outputs.

Verbs-of-art (`Send Keys`, `Pipe Pane`, `Snapshot Pane`, `Capture Pane`, `Paste Text`) stay generic — the verb is already a tmux-specific term and over-prefixing reads as visual chrome.

Pure display-time lever — title is **not** in BM25's search corpus (verified vs FastMCP's `_extract_searchable_text`), so this won't shift activation behavior. It just makes the catalog readable when a user has multiple MCPs sharing the noun.

## Test plan

- [x] `uv run ruff check . --fix && uv run ruff format .`
- [x] `uv run mypy`
- [x] `uv run py.test --reruns 0 -vvv` (430 passed; +2 title-audit tests)
- [x] `just build-docs`