### PR TITLE
pyproject: expand PyPI keywords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,17 @@ classifiers = [
   "Typing :: Typed",
 ]
 
-keywords = ["tmux", "mcp", "model-context-protocol", "terminal", "ai"]
+keywords = [
+  "tmux",
+  "pane",
+  "window",
+  "session",
+  "terminal",
+  "terminal-multiplexer",
+  "mcp",
+  "model-context-protocol",
+  "ai",
+]
 homepage = "http://github.com/tmux-python/libtmux-mcp/"
 readme = "README.md"
 packages = [


### PR DESCRIPTION
## Summary

Adds `pane`, `window`, `session`, and `terminal-multiplexer` to `pyproject.toml` keywords so the package surfaces on PyPI search for the most common user vocabulary. A user searching for *"tmux session pane MCP"* should see this package.

```toml
keywords = [
  "tmux",
  "pane",
  "window",
  "session",
  "terminal",
  "terminal-multiplexer",
  "mcp",
  "model-context-protocol",
  "ai",
]
```

Reformatted to one-per-line for cleaner future diffs.

Honest note: most MCP discovery happens through clients (Claude Code's catalog) rather than PyPI search, so this is a modest hedge rather than a primary discovery mechanism.

## Test plan

- [x] `uv run ruff check . && uv run mypy && uv run py.test -q` (428 passed)
- [x] `just build-docs`