### PR TITLE
Smoke test: pin libtmux to tmux-python/libtmux#672

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,12 @@ sphinx-gp-theme = false
 sphinx-ux-autodoc-layout = false
 sphinx-ux-badges = false
 
+[tool.uv.sources]
+# Temporary smoke-test pin against the libtmux 0.57.0 parity branch
+# (tmux-python/libtmux PR #672). Revert once 0.57.0 ships on PyPI and
+# the dependencies constraint bumps to >=0.57.0.
+libtmux = { git = "https://github.com/tmux-python/libtmux.git", branch = "parity-pt-2" }
+
 [tool.mypy]
 strict = true
 python_version = "3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.56.0"
-source = { git = "https://github.com/tmux-python/libtmux.git?branch=parity-pt-2#426b18a6b6a9d272623173d40456e24dacc22bc2" }
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=parity-pt-2#81a021ed8de455ed97bb12ae4ba6adcda434da24" }
 
 [[package]]
 name = "libtmux-mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.56.0"
-source = { git = "https://github.com/tmux-python/libtmux.git?branch=parity-pt-2#78f425abe586e845d580092c69353bab71b7d42b" }
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=parity-pt-2#426b18a6b6a9d272623173d40456e24dacc22bc2" }
 
 [[package]]
 name = "libtmux-mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -1121,11 +1121,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.56.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/62/896e1e0412dd76c88926604d5a231feb9b116d6f32abe19054e244504dbc/libtmux-0.56.0.tar.gz", hash = "sha256:bddf52214405e4f64850826d44cbc958d4a01c53432983cee0e2856bdbbaaedb", size = 476168, upload-time = "2026-05-10T13:40:23.774Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/ce/4319c912164fa142956c73ba50ed6f2aac2ca7cced2e96c8320114f1c937/libtmux-0.56.0-py3-none-any.whl", hash = "sha256:ddf70de0f287666fb0f02082732f28eed46450de1828c995da3de2b12042ab60", size = 97768, upload-time = "2026-05-10T13:40:22.189Z" },
-]
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=parity-pt-2#78f425abe586e845d580092c69353bab71b7d42b" }
 
 [[package]]
 name = "libtmux-mcp"
@@ -1188,7 +1184,7 @@ testing = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.2.4,<4.0.0" },
-    { name = "libtmux", specifier = ">=0.56.0,<1.0" },
+    { name = "libtmux", git = "https://github.com/tmux-python/libtmux.git?branch=parity-pt-2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Draft smoke-test PR pinning libtmux to the `parity-pt-2` branch
(tmux-python/libtmux#672) via `[tool.uv.sources]`. Not for merge —
this verifies libtmux-mcp's test suite passes against libtmux 0.57.0
before that release ships on PyPI.

The branch's CHANGES entry for `LibTmuxException.subcommand` calls
out `handle_tool_errors` as a downstream consumer; once the pin is
verified, follow-up PRs can surface the new `subcommand` field
through `ToolError` mapping.

## Disposition

Close (or rebase onto a PyPI-pinned PR) once libtmux 0.57.0 lands
on PyPI and the standard dependency-constraint bump replaces this
git pin.

## Test plan

- [x] `just test` locally (462 passed)
- [ ] CI matrix (tmux 3.2a → master) green on this branch