### PR TITLE
mcp(fix[middleware]): Stop error logging from masking the tool result

### DIFF
--- a/src/libtmux_mcp/middleware.py
+++ b/src/libtmux_mcp/middleware.py
@@ -27,6 +27,7 @@ Provides the project's middleware infrastructure, in definition order:
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import logging
 import time
@@ -425,7 +426,15 @@ class ToolErrorResultMiddleware(ErrorHandlingMiddleware):
         try:
             return await call_next(context)
         except Exception as error:
-            self._log_error(error, context)
+            # Invariant: error logging must never mask the tool result. A
+            # broken logging handler (e.g. a stale rich.traceback import
+            # after the venv was rebuilt under a long-lived server) would
+            # otherwise raise out of ``_log_error`` and replace the real
+            # failure with a misleading ``Internal error``. Suppress
+            # silently — logging the failure here would re-enter the same
+            # broken handler. See #66.
+            with contextlib.suppress(Exception):
+                self._log_error(error, context)
             return _error_tool_result(error, context)
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1232,6 +1232,68 @@ def test_tool_error_result_logs_at_error_log_level(
     assert levels == [expected_level]
 
 
+class LogMaskingCase(t.NamedTuple):
+    """One ``on_call_tool`` scenario for the logging-masks-result guard."""
+
+    test_id: str
+    logger_raises: bool
+
+
+LOG_MASKING_CASES: tuple[LogMaskingCase, ...] = (
+    LogMaskingCase(test_id="logging-ok", logger_raises=False),
+    LogMaskingCase(test_id="logging-raises", logger_raises=True),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    LOG_MASKING_CASES,
+    ids=[case.test_id for case in LOG_MASKING_CASES],
+)
+def test_error_logging_never_masks_tool_result(
+    case: LogMaskingCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing logging handler must not replace the real tool error.
+
+    Regression guard for #66: when the active logging handler raised
+    while formatting the error record (e.g. a stale ``rich.traceback``
+    import after the venv was rebuilt under a long-lived server),
+    ``_log_error`` escaped ``on_call_tool``'s ``except`` and the stock
+    transform surfaced a misleading ``Internal error`` in place of the
+    real failure. The call site now suppresses logging exceptions so
+    the original error always reaches ``_error_tool_result``.
+    """
+    from libtmux_mcp.middleware import ToolErrorResultMiddleware
+
+    middleware = ToolErrorResultMiddleware(transform_errors=True)
+    if case.logger_raises:
+
+        def _boom(*_args: t.Any, **_kwargs: t.Any) -> None:
+            msg = "No module named 'rich.traceback'"
+            raise ModuleNotFoundError(msg)
+
+        monkeypatch.setattr(middleware.logger, "log", _boom)
+
+    async def _call_next(_context: t.Any) -> str:
+        msg = "real tool failure"
+        raise RuntimeError(msg)
+
+    ctx: MiddlewareContext[CallToolRequestParams] = MiddlewareContext(
+        message=CallToolRequestParams(name="boom_tool", arguments={}),
+    )
+
+    result = asyncio.run(middleware.on_call_tool(ctx, _call_next))
+
+    assert result.is_error is True
+    text = result.content[0].text
+    assert "real tool failure" in text
+    assert "rich.traceback" not in text
+    # ``_log_error`` bumps the counter before it reaches the log call,
+    # so the counter advances whether or not logging then fails.
+    assert sum(middleware.error_counts.values()) == 1
+
+
 def test_schema_validation_failure_marked_expected_in_meta() -> None:
     """Argument-schema failures report ``expected=True`` in result meta.
 


### PR DESCRIPTION
## Summary

A failure in the error-*logging* path could replace the real tool error. `ToolErrorResultMiddleware.on_call_tool` logged the error before converting it, and `_log_error`'s `self.logger.log(..., exc_info=...)` call was unguarded — so when the active handler raised while formatting the record, the logging exception escaped the `except` block and `_error_tool_result` never ran. The stock fastmcp transform then surfaced a misleading `Internal error: …` in place of the real failure.

The concrete trigger we hit: a long-lived stdio server whose virtualenv was rebuilt underneath it. fastmcp's `RichHandler` lazily imports `rich.traceback` the first time it renders an `exc_info` record; after the rebuild that import raised `ModuleNotFoundError`, and **every** tool call surfaced `Internal error: No module named 'rich.traceback'` — masking both the cause and the remedy (reconnect the server). The defect is independent of that trigger: any handler failure could mask a real tool error.

The asymmetry that pinpointed it: the `error_callback` invocation immediately below in `_log_error` is already wrapped in `try/except`; the `logger.log` call on the same path was not.

## Changes

- **`src/libtmux_mcp/middleware.py`**: wrap the `_log_error` call in `on_call_tool` with `contextlib.suppress(Exception)`, guaranteeing `_error_tool_result` always runs. The suppress is silent by design — logging the failure would re-enter the same broken handler.
- **`tests/test_middleware.py`**: parametrized regression test (`logging-ok` / `logging-raises`) driving `on_call_tool` with a `call_next` that raises a known error and a logger patched to raise; asserts the original error text survives and the `rich.traceback` message never leaks into the result.

A follow-up worth considering separately (not in this PR): fail fast at startup — eagerly import the traceback dependency or run a one-shot self-check so a broken environment surfaces loudly at launch rather than on the first tool call.

Fixes #66.

## Test plan

- [x] New test fails on `main` (drop the `suppress`, `logging-raises` reproduces the `ModuleNotFoundError` escape) and passes with the fix.
- [x] `uv run ruff format .` / `uv run ruff check . --fix --show-fixes` — clean.
- [x] `uv run mypy` — no issues.
- [x] `uv run pytest` — full suite green.
