### PR TITLE
Bump fastmcp minimum to 3.4.2 for the Starlette CVE floor

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@ _Notes on upcoming releases will be added here_
 
 ### Dependencies
 
-**Minimum `fastmcp>=3.4.2`** (was `>=3.4.0`). Picks up fastmcp 3.4.1's explicit `starlette>=1.0.1` floor, so installs can no longer resolve to a Starlette version affected by CVE-2026-48710 — previously this was constrained only transitively through `mcp`.
+**Minimum `fastmcp>=3.4.2`** (was `>=3.4.0`). Picks up fastmcp 3.4.1's explicit `starlette>=1.0.1` floor, so installs can no longer resolve to a Starlette version affected by CVE-2026-48710 — previously this was constrained only transitively through `mcp`. (#77)
 
 ### What's new
 

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,10 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+**Minimum `fastmcp>=3.4.2`** (was `>=3.4.0`). Picks up fastmcp 3.4.1's explicit `starlette>=1.0.1` floor, so installs can no longer resolve to a Starlette version affected by CVE-2026-48710 — previously this was constrained only transitively through `mcp`.
+
 ### What's new
 
 **One-call command completion with {tooliconl}`run-command`**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ include = [
 
 dependencies = [
   "libtmux>=0.58.0,<1.0",
-  "fastmcp>=3.4.0,<4.0.0",
+  "fastmcp>=3.4.2,<4.0.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1242,7 +1242,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.4.0,<4.0.0" },
+    { name = "fastmcp", specifier = ">=3.4.2,<4.0.0" },
     { name = "libtmux", specifier = ">=0.58.0,<1.0" },
 ]
 


### PR DESCRIPTION
## Summary

- **Raise** the `fastmcp` floor from `>=3.4.0` to `>=3.4.2`, picking up fastmcp 3.4.1's explicit `starlette>=1.0.1` floor so installs can no longer resolve to a Starlette affected by CVE-2026-48710 — previously this was constrained only transitively through `mcp`.
- **Lock** now resolves `fastmcp` to `3.4.2` and `starlette` to `1.2.1`.
- **Document** the bump under `### Dependencies` in the unreleased changelog.

Background: the floor was deliberately held at `>=3.4.0` while `3.4.1`/`3.4.2` were inside the local uv dependency cooldown; that window has now cleared.

## Verification

The runtime floor is raised:

```console
rg 'fastmcp>=3.4.2' pyproject.toml
```

The lock satisfies the Starlette CVE floor:

```console
rg -A2 '^name = "starlette"' uv.lock
```

## Test plan

- [x] `uv run ruff check .` — lint clean
- [x] `uv run ruff format .` — formatting unchanged
- [x] `uv run mypy .` — type-check clean
- [x] `uv run py.test --reruns 0` — full suite green
- [x] `just build-docs` — docs build, CHANGES renders and tool roles resolve
