### PR TITLE
mcp(test[middleware]): Fix caplog double-capture on pytest 9.1.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,12 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Development
+
+**Minimum `pytest>=9.1.0`**
+
+The dev and test dependency groups now require pytest 9.1.0 or newer. (#83)
+
 ## libtmux-mcp 0.1.0a14 (2026-06-14)
 
 libtmux-mcp 0.1.0a14 adds tier-aware tool batching. {tooliconl}`call-readonly-tools-batch`, {tooliconl}`call-mutating-tools-batch`, and {tooliconl}`call-destructive-tools-batch` run an ordered list of existing MCP tools in a single call and return a per-operation result for each, preserving every nested tool's own structured output. Each wrapper caps the safety tier of the calls it will make — regardless of the server's `LIBTMUX_SAFETY` tier — and `on_error` selects stop-at-first-failure or continue-and-report handling. Aggregate results stay within the server's response limit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
   # Testing
   "typing-extensions; python_version < '3.11'",
   "gp-libs",
-  "pytest",
+  "pytest>=9.1.0",  # >=9.1.0 attaches caplog to non-propagating loggers; see test_middleware
   "pytest-rerunfailures",
   "pytest-mock",
   "pytest-watcher",
@@ -91,7 +91,7 @@ docs = [
 testing = [
   "typing-extensions; python_version < '3.11'",
   "gp-libs",
-  "pytest",
+  "pytest>=9.1.0",  # >=9.1.0 attaches caplog to non-propagating loggers; see test_middleware
   "pytest-rerunfailures",
   "pytest-mock",
   "pytest-watcher",

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1109,7 +1109,6 @@ def test_tool_error_result_logs_at_error_log_level(
     expected_level: int,
     message_fragment: str,
     caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``_log_error`` honors ``log_level``: WARNING expected, ERROR not.
 
@@ -1127,10 +1126,10 @@ def test_tool_error_result_logs_at_error_log_level(
     """
     from fastmcp import Client
 
-    # fastmcp's logger doesn't propagate to root (rich handler);
-    # re-enable propagation so caplog sees the records.
-    monkeypatch.setattr(logging.getLogger("fastmcp"), "propagate", True)
-
+    # fastmcp's logger is non-propagating (rich handler); pytest >=9.1.0
+    # attaches caplog directly to it. ``fastmcp.errors`` records reach
+    # caplog by propagating up to ``fastmcp`` — re-enabling propagation
+    # to root would then double-capture each emit (``fastmcp`` + root).
     probe = _error_probe_server()
 
     async def _call() -> None:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -448,7 +448,6 @@ def test_send_keys_batch_schema_validation_redacts_inputs(
     secret: str,
     expected_fragments: tuple[str, ...],
     caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Malformed batch schema errors do not echo raw key payloads."""
     from fastmcp import Client
@@ -456,8 +455,6 @@ def test_send_keys_batch_schema_validation_redacts_inputs(
     from libtmux_mcp.server import build_mcp_server
 
     assert test_id
-    for logger_name in ("fastmcp", "fastmcp.server.server", "fastmcp.errors"):
-        monkeypatch.setattr(logging.getLogger(logger_name), "propagate", True)
 
     async def _call() -> t.Any:
         async with Client(build_mcp_server()) as client:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -914,7 +914,6 @@ def test_map_exception_operator_faults_stay_at_error(raised: Exception) -> None:
 
 def test_expected_tool_error_logs_warning_through_server(
     caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Fastmcp's server-layer error log honors ``ExpectedToolError.log_level``.
 
@@ -922,10 +921,6 @@ def test_expected_tool_error_logs_warning_through_server(
     assertion isolates fastmcp's own ``Error calling tool`` record —
     the project middleware's log behavior is covered in
     ``test_middleware.py``.
-
-    fastmcp sets ``propagate = False`` on its logger (it installs a
-    rich handler instead), which hides records from caplog's
-    root-logger handler — re-enable propagation for the test.
     """
     import asyncio
     import logging
@@ -933,8 +928,6 @@ def test_expected_tool_error_logs_warning_through_server(
     from fastmcp import Client, FastMCP
 
     from libtmux_mcp._utils import ExpectedToolError
-
-    monkeypatch.setattr(logging.getLogger("fastmcp"), "propagate", True)
 
     probe = FastMCP(name="probe")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1261,7 +1261,7 @@ dev = [
     { name = "gp-libs" },
     { name = "gp-sphinx", specifier = "==0.0.1a31" },
     { name = "mypy" },
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=9.1.0" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
@@ -1289,7 +1289,7 @@ lint = [
 ]
 testing = [
     { name = "gp-libs" },
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=9.1.0" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },


### PR DESCRIPTION
## Summary

- **Fix** `test_tool_error_result_logs_at_error_log_level`, which fails on pytest 9.1.0 because `caplog` records each error-log emit twice (`assert [30, 30] == [30]`). This reds `main` and any branch carrying the dev-dependency bump.
- **Remove** the obsolete `propagate=True` workaround suite-wide — the failing test plus two sister tests (`test_send_keys_batch_schema_validation_redacts_inputs`, `test_expected_tool_error_logs_warning_through_server`) all forced `fastmcp` logger propagation so `caplog` could see records. pytest 9.1.0 captures non-propagating loggers natively, making the workaround dead weight that double-captures each emit.
- **Floor** `pytest>=9.1.0` in the `dev` and `testing` groups so the suite's reliance on that capture behavior is a declared contract, not an implicit one.

## Root cause

fastmcp keeps its `fastmcp` logger non-propagating (it owns a Rich handler). The tests compensated by forcing `fastmcp.propagate = True` so `caplog` — which historically only listened at the root logger — could see the records.

pytest 9.1.0 shipped [#3697 "Logging capture now works for non-propagating loggers"](https://github.com/pytest-dev/pytest/issues/3697): `catching_logs.__enter__` now attaches its `LogCaptureHandler` directly to every non-propagating logger at setup, including `fastmcp`. A record emitted on `fastmcp.errors` reaches `caplog` by propagating up to `fastmcp` (where the handler now lives); re-enabling propagation to root captures the same emit a second time.

The error is logged once — only the *capture* was doubled:

| Test setup | Records `caplog` sees |
|---|---|
| With `propagate=True` workaround (before) | 2 |
| Without the workaround (after) | 1 |

`test_tool_error_result_logs_at_error_log_level` asserts an exact record count, so it failed outright. The two sister tests assert on log *content*, so the duplication was silent — but the workaround was equally obsolete there.

## Changes by area

- **`tests/test_middleware.py`**: Drop the `propagate=True` workaround (and now-unused `monkeypatch` arg) from `test_tool_error_result_logs_at_error_log_level` and `test_send_keys_batch_schema_validation_redacts_inputs`; `caplog` captures fastmcp's logger natively.
- **`tests/test_utils.py`**: Drop the same workaround from `test_expected_tool_error_logs_warning_through_server`, including the docstring paragraph that described it.
- **`pyproject.toml`** / **`uv.lock`**: Floor `pytest>=9.1.0` in `dev` and `testing`; relock.
- **`CHANGES`**: Add a `### Development` entry.

## Verification

The workaround is fully removed from the test suite (the `monkeypatch.setattr(..., "propagate", ...)` target):

```
rg -n '"propagate"' tests/
```

The floor is declared in both dependency groups:

```
rg -n 'pytest>=9\.1\.0' pyproject.toml
```

## Test plan

- [x] `test_tool_error_result_logs_at_error_log_level` (all parametrizations) passes with `--reruns 0`
- [x] `test_send_keys_batch_schema_validation_redacts_inputs` and `test_expected_tool_error_logs_warning_through_server` pass without the workaround
- [x] `uv run ruff check .` and `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] Full suite green with `uv run pytest --reruns 0`
- [x] `just build-docs`