### PR TITLE
py(deps[libtmux]) Bump 0.58.0 -> 0.60.0 (tmux 3.7 feature parity)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,10 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+**Minimum `libtmux>=0.60.0`** (was `>=0.58.0`). Picks up libtmux 0.59.0's initial tmux 3.7 support and 0.60.0's completion of tmux 3.7 feature parity — floating panes, typed tmux 3.7 server, session, window, and pane options, new pane format variables, and new command flags. Every 3.7-only surface is version-gated, so tmux 3.2a-3.6 keep working unchanged, and the bump requires no server code or test changes. (#85)
+
 ### Development
 
 **Minimum `pytest>=9.1.0`**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ include = [
 ]
 
 dependencies = [
-  "libtmux>=0.58.0,<1.0",
+  "libtmux>=0.60.0,<1.0",
   "fastmcp>=3.4.2,<4.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1163,11 +1163,11 @@ wheels = [
 
 [[package]]
 name = "libtmux"
-version = "0.58.1"
+version = "0.60.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/58/346776e0491ede33e1554a4bff9b545dbe9f3164e45abac483195938a1cf/libtmux-0.58.1.tar.gz", hash = "sha256:a294dd585aa419d4ecce36f3e55df656693743c97a0b5b5bb1e5fea31ada2482", size = 519541, upload-time = "2026-06-17T00:03:31.81Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/c2fc23e871855cb3feb5119ab3426656b2caa83f220fb6f1b7a770cb887e/libtmux-0.60.0.tar.gz", hash = "sha256:03d9740fd18090378a1f1a763403b127808b327b1466a1d3812c562f595ce06f", size = 527549, upload-time = "2026-06-28T21:19:35.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/4d/e44ada32edfe947c40d4dfc596a6f5355400a16d08be06016bd754375e41/libtmux-0.58.1-py3-none-any.whl", hash = "sha256:ab0f47d03a59d674962bc23e36e188fcfa4a82b0f270d474afab519e3076839b", size = 113653, upload-time = "2026-06-17T00:03:30.48Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c3/e524f498fe5dfc26c975ec8b52332fdd0b50e020f3ecc09423ba5d4ebc61/libtmux-0.60.0-py3-none-any.whl", hash = "sha256:a085e5653709d9e1c809c68f7daf1cd55c8af1ca938eb1e866388b9b13905ed3", size = 117368, upload-time = "2026-06-28T21:19:33.635Z" },
 ]
 
 [[package]]
@@ -1231,7 +1231,7 @@ testing = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.4.2,<4.0.0" },
-    { name = "libtmux", specifier = ">=0.58.0,<1.0" },
+    { name = "libtmux", specifier = ">=0.60.0,<1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- **Bump** the `libtmux` floor `>=0.58.0,<1.0` → `>=0.60.0,<1.0` in `pyproject.toml`, with `uv.lock` regenerated to match.
- **Adopt** libtmux 0.60.0, which completes tmux 3.7 feature parity at the library layer libtmux-mcp wraps — floating panes, typed 3.7 options, new pane format variables, and new command flags. The floor crosses 0.59.0 (initial tmux 3.7 support) on the way.
- **No migration needed**: every upstream addition is additive and version-gated, so the server's behavior and its tmux 3.2a–3.6 support are unchanged. This is a pure floor bump — no new MCP tools, no server code, and no test changes.

## Upstream — libtmux 0.60.0 (#694)

| Area | What 0.60.0 adds (all version-gated to tmux 3.7+) |
|---|---|
| Floating panes | `Window.new_pane()` / `Pane.new_pane()` |
| Options | Typed tmux 3.7 server / session / window / pane options |
| Pane formats | Floating geometry & flags, OSC 9;4 progress, screen-mode flags |
| Command flags | `capture_pane`, `split`, `Session.kill`, `paste_buffer`, `command_prompt`, `list_keys`, `run_shell`, `refresh_client` |

Release: https://github.com/tmux-python/libtmux/releases/tag/v0.60.0
Changelog: https://libtmux.git-pull.com/history.html#libtmux-0-60-0-2026-06-28

## Verification

The old floor is gone from the manifest:

```console
$ rg 'libtmux>=0\.58' pyproject.toml
```

The new floor is in place:

```console
$ rg 'libtmux>=0\.60\.0,<1\.0' pyproject.toml
```

## Test plan

- [x] Full suite passes serially against libtmux 0.60.0 — `uv run pytest --reruns 0`
- [x] `uv run mypy` (strict) clean — libtmux 0.60.0's typed surface still satisfies the server's annotations
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean
- [x] `just build-docs` succeeds with no new Sphinx warnings on the changelog page

## Out of scope

`docs/tools/pane/capture-since.md` deep-links libtmux source at the `v0.58.0` tag. The link still resolves, so it's left untouched here; repointing it to `v0.60.0` can ride a later docs pass.