### PR TITLE
Bump libtmux floor to 0.61.0, refresh dev dependencies

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,10 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+**Minimum `libtmux>=0.61.0`** (was `>=0.60.0`). Picks up libtmux 0.61.0's hardening of the tmux 3.7 patch line, so the server runs cleanly against tmux 3.7a and 3.7b. Every 3.7-only surface stays version-gated, so tmux 3.2a-3.6 keep working unchanged, and the bump requires no server code or test changes. (#86)
+
 ## libtmux-mcp 0.1.0a15 (2026-06-28)
 
 libtmux-mcp 0.1.0a15 raises the libtmux floor to 0.60.0, which completes tmux 3.7 feature parity at the library layer the server wraps — floating panes, typed tmux 3.7 options, new pane format variables, and new command flags. Every 3.7-only surface is version-gated, so tmux 3.2a-3.6 keep working unchanged. The dev and test dependency groups also move to pytest 9.1.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ include = [
 ]
 
 dependencies = [
-  "libtmux>=0.60.0,<1.0",
+  "libtmux>=0.61.0,<1.0",
   "fastmcp>=3.4.2,<4.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2874,14 +2874,14 @@ wheels = [
 
 [[package]]
 name = "syrupy"
-version = "5.3.4"
+version = "5.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/17/95753634cd02a892cbc74d8df9c15f5ad053885a913eb11aa6061f278344/syrupy-5.3.4.tar.gz", hash = "sha256:10f192655a2d42473ad5772653e64b281f6823fe5e30458d92f8ca8e882884c1", size = 87078, upload-time = "2026-06-26T10:55:42.522Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/35/0052946e6318109af9eecaa35e1a18c49ee8765702eb1e2177071fe779b4/syrupy-5.4.0.tar.gz", hash = "sha256:cc166e6331c735b7acc93074f9b171dd1b130444e944b185aa5123767b49b76f", size = 87881, upload-time = "2026-07-01T15:30:11.756Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/7a/254f95860cebb6d51ddb3e815ee30085e8c8a3ba6df1f44ef4605b385621/syrupy-5.3.4-py3-none-any.whl", hash = "sha256:409348aa20afc4b7dab7c965331de0cd79ab46977877fb189014ce9294e947e5", size = 53103, upload-time = "2026-06-26T10:55:41.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/80/0c7095f357afeb52100d312250354d2e76afb779c81fe3fb52118076fa5a/syrupy-5.4.0-py3-none-any.whl", hash = "sha256:3079017f0c6d3c1b293b57ad2af15cc7851d8eceba922896bdb3bc4834df4ce8", size = 53364, upload-time = "2026-07-01T15:30:10.332Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1234,7 +1234,7 @@ testing = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.4.2,<4.0.0" },
-    { name = "libtmux", specifier = ">=0.60.0,<1.0" },
+    { name = "libtmux", specifier = ">=0.61.0,<1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- **Raise** minimum `libtmux>=0.61.0` (was `>=0.60.0`). libtmux 0.61.0 hardens support for the tmux 3.7 patch line — `break_pane()` keeps tmux's default window name on 3.7a/3.7b, a new `get_version_str()` helper exposes the raw version string with its point-release suffix, and the library's test suite now passes against tmux 3.7a/3.7b. These are library-level changes; the bump keeps the floor aligned with the library the server wraps and requires no server or test changes.
- **Bump** dev/test dependency `syrupy` 5.3.4 → 5.4.0.

## Changes

- **`pyproject.toml`** — `libtmux` runtime specifier `>=0.60.0,<1.0` → `>=0.61.0,<1.0`.
- **`uv.lock`** — regenerated for the new `libtmux` floor and the resolved `syrupy` 5.4.0 sdist/wheels.

## Test plan

- [x] `uv run ruff check .` — lint clean
- [x] `uv run ruff format --check .` — formatting clean
- [x] `uv run mypy` — strict type check clean
- [x] `uv run pytest` — full suite green against libtmux 0.61.0 and syrupy 5.4.0