### PR TITLE
Do not retry a stale id; say how to fix an ambiguous target

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,32 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+**Minimum `libtmux>=0.62.0`** (was `>=0.61.0`). Picks up libtmux 0.62.0, which
+re-parents {exc}`libtmux.exc.MultipleObjectsReturned` and
+{exc}`libtmux.exc.ObjectDoesNotExist` under {exc}`libtmux.exc.LibTmuxException`.
+The retry and error-mapping fixes below rely on that hierarchy. (#98)
+
+### Fixes
+
+**A stale id fails once instead of twice**
+
+Readonly tools retried on any {exc}`libtmux.exc.LibTmuxException`, the right
+trigger for the transient socket errors libtmux wraps but wrong for the rest of
+that family — a pane that does not exist will not exist on the second look, and
+an ambiguous match does not become unambiguous during a backoff window. A lookup
+that a retry cannot change now fails on the first attempt, without the redundant
+tmux round-trip and its backoff delay. (#98)
+
+**An ambiguous target says how to disambiguate it**
+
+A window shared between sessions — through a grouped session or `link-window` —
+is listed once per session that holds it, so a name or index can match more than
+one row and the lookup raises {exc}`libtmux.exc.MultipleObjectsReturned`. That
+reached the agent with no recovery hint. It now says to target the object by id
+instead. (#98)
+
 ## libtmux-mcp 0.1.0a17 (2026-07-11)
 
 libtmux-mcp 0.1.0a17 makes best-effort shell-history suppression the default for {tooliconl}`run-command` — calls that omit `suppress_history` now inherit the server default, and setting {envvar}`LIBTMUX_SUPPRESS_HISTORY` to `0` restores the previous behavior. Spawned shells gain the same hygiene: {tooliconl}`create-session`, {tooliconl}`create-window`, {tooliconl}`split-window`, and {tooliconl}`respawn-pane` accept `suppress_persistent_history=true` for best-effort no-disk history controls. {tooliconl}`create-window` and {tooliconl}`split-window` also accept per-process `environment` mappings, and the MCP install picker now covers Grok CLI and Antigravity.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ include = [
 ]
 
 dependencies = [
-  "libtmux>=0.61.0,<1.0",
+  "libtmux>=0.62.0,<1.0",
   "fastmcp>=3.4.2,<4.0.0",
 ]
 

--- a/src/libtmux_mcp/_utils.py
+++ b/src/libtmux_mcp/_utils.py
@@ -1001,11 +1001,20 @@ def _map_exception_to_tool_error(fn_name: str, e: BaseException) -> ToolError:
         return ExpectedToolError(str(e))
     if isinstance(e, exc.BadSessionName):
         return ExpectedToolError(str(e))
-    if isinstance(e, exc.TmuxObjectDoesNotExist):
+    if isinstance(e, exc.ObjectDoesNotExist):
         return ExpectedToolError(
             f"Object not found: {e}",
             suggestion=(
                 "Call list_sessions / list_windows / list_panes to discover valid ids."
+            ),
+        )
+    if isinstance(e, exc.MultipleObjectsReturned):
+        return ExpectedToolError(
+            f"Ambiguous target: {e}",
+            suggestion=(
+                "A window shared between sessions is listed once per session that "
+                "holds it, so a name or index can match more than one row. Target "
+                "it by id (session_id / window_id / pane_id) instead."
             ),
         )
     if isinstance(e, exc.PaneNotFound):

--- a/src/libtmux_mcp/middleware.py
+++ b/src/libtmux_mcp/middleware.py
@@ -666,6 +666,45 @@ class AuditMiddleware(Middleware):
 DEFAULT_RESPONSE_LIMIT_BYTES = 1_000_000
 
 
+#: Failures a retry cannot fix. Each one names a thing that is not there, or a
+#: request that cannot succeed as written, so re-running it buys a second tmux
+#: round-trip and a backoff window in order to fail identically. They all
+#: descend from :exc:`libtmux.exc.LibTmuxException`, which is the retry
+#: trigger, so without this set they would all be retried.
+#:
+#: Order the entries most-general-first when reading: ``ObjectDoesNotExist``
+#: already covers :exc:`libtmux.exc.TmuxObjectDoesNotExist`.
+NON_RETRYABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
+    libtmux_exc.ObjectDoesNotExist,
+    libtmux_exc.MultipleObjectsReturned,
+    libtmux_exc.PaneNotFound,
+    libtmux_exc.NoWindowsExist,
+    libtmux_exc.BadSessionName,
+    libtmux_exc.TmuxSessionExists,
+    libtmux_exc.TmuxCommandNotFound,
+)
+
+
+class _SkipDeterministicFailures(RetryMiddleware):
+    """A :class:`RetryMiddleware` that declines to retry what cannot succeed.
+
+    fastmcp decides whether to retry in ``_should_retry``, matching the error
+    and, one hop down, its ``__cause__`` -- which is where the real failure
+    lives, because ``handle_tool_errors`` re-raises every libtmux error as an
+    ``ExpectedToolError`` chained off the original. This narrows that decision
+    with :data:`NON_RETRYABLE_EXCEPTIONS`, checking the same two places.
+    """
+
+    def _should_retry(self, error: Exception) -> bool:
+        """Return ``False`` for a failure a second attempt cannot change."""
+        cause = error.__cause__
+        if isinstance(error, NON_RETRYABLE_EXCEPTIONS) or (
+            cause is not None and isinstance(cause, NON_RETRYABLE_EXCEPTIONS)
+        ):
+            return False
+        return super()._should_retry(error)
+
+
 class ReadonlyRetryMiddleware(Middleware):
     """Retry transient libtmux failures, but only for readonly tools.
 
@@ -683,6 +722,12 @@ class ReadonlyRetryMiddleware(Middleware):
     (socket EAGAIN, transient connect errors). The fastmcp default
     ``(ConnectionError, TimeoutError)`` does NOT match these, so the
     upstream defaults would be a silent no-op.
+
+    That trigger is a whole family, though, and most of it is not
+    transient: a pane that does not exist will not exist on the second
+    look. :data:`NON_RETRYABLE_EXCEPTIONS` carves those out, so a stale
+    id fails once instead of costing a backoff window and a second tmux
+    round-trip to fail again.
 
     Place this in the middleware stack **inside** ``AuditMiddleware``
     (so retried calls are audited once each) and **outside**
@@ -715,7 +760,7 @@ class ReadonlyRetryMiddleware(Middleware):
         """
         if logger_ is None:
             logger_ = logging.getLogger("libtmux_mcp.retry")
-        self._retry = RetryMiddleware(
+        self._retry = _SkipDeterministicFailures(
             max_retries=max_retries,
             base_delay=base_delay,
             max_delay=max_delay,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -9,7 +9,9 @@ import typing as t
 
 import pydantic
 import pytest
+from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import MiddlewareContext
+from libtmux import exc as libtmux_exc
 from mcp.types import CallToolRequestParams
 
 from libtmux_mcp._utils import TAG_DESTRUCTIVE, TAG_MUTATING, TAG_READONLY
@@ -913,6 +915,90 @@ def test_readonly_retry_recovers_on_decorated_tool(
         f"retry did not fire (calls={calls['count']}). Likely cause: "
         f"fastmcp<3.2.4 RetryMiddleware._should_retry not walking "
         f"__cause__. Bump pyproject.toml fastmcp pin to >=3.2.4."
+    )
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [
+        libtmux_exc.TmuxObjectDoesNotExist("@99"),
+        libtmux_exc.MultipleObjectsReturned(count=2, query={"pane_id": "%0"}),
+        libtmux_exc.PaneNotFound("%99"),
+        libtmux_exc.NoWindowsExist,
+        libtmux_exc.BadSessionName(reason="contains periods", session_name="a.b"),
+        libtmux_exc.TmuxSessionExists("session exists"),
+    ],
+    ids=lambda e: type(e).__name__ if isinstance(e, Exception) else e.__name__,
+)
+def test_readonly_retry_skips_deterministic_failures(raised: Exception) -> None:
+    """A failure a second attempt cannot change is not retried.
+
+    Every one of these descends from ``LibTmuxException``, which is the retry
+    trigger — so without :data:`NON_RETRYABLE_EXCEPTIONS` they would all be
+    retried. None of them can succeed on the second look: a pane that is not
+    there will not appear during a backoff window, and an ambiguous match does
+    not become unambiguous. Retrying buys a second tmux round-trip and 100 ms
+    of latency in order to fail identically.
+    """
+    middleware = ReadonlyRetryMiddleware(max_retries=1, base_delay=0.0)
+    ctx = _retry_context(tags={TAG_READONLY})
+    call_next = _FlakyCallNext(raises_n_times=1, exception=raised)
+
+    with pytest.raises(libtmux_exc.LibTmuxException):
+        asyncio.run(middleware.on_call_tool(ctx, call_next))
+
+    assert call_next.calls == 1, (
+        f"{type(raised).__name__} was retried. It descends from LibTmuxException, "
+        f"so it must be listed in NON_RETRYABLE_EXCEPTIONS."
+    )
+
+
+def test_readonly_retry_skips_not_found_on_decorated_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a stale id is not retried through the production wrap path.
+
+    The unit test above raises straight into the middleware. This one goes
+    through ``handle_tool_errors``, which re-raises every libtmux failure as an
+    ``ExpectedToolError`` chained off the original — so at the middleware layer
+    the exception is an ``ExpectedToolError`` and the real failure is only
+    visible one hop down, on ``__cause__``. The retry decision walks that hop
+    (which is what makes retries work at all), so the *skip* decision has to
+    walk it too, or it never fires in production.
+
+    Guards the shape libtmux tmux-python/libtmux#718 introduced:
+    ``TmuxObjectDoesNotExist`` became a ``LibTmuxException``, which silently
+    made every stale session or window id retryable.
+    """
+    from libtmux import Server
+
+    from libtmux_mcp.tools.server_tools import list_sessions
+
+    calls = {"count": 0}
+
+    def _missing_sessions(_self: Server) -> list[t.Any]:
+        calls["count"] += 1
+        raise libtmux_exc.TmuxObjectDoesNotExist(
+            obj_key="session_id",
+            obj_id="$99",
+            list_cmd="list-sessions",
+            list_extra_args=None,
+        )
+
+    monkeypatch.setattr(Server, "sessions", property(_missing_sessions))
+
+    middleware = ReadonlyRetryMiddleware(max_retries=1, base_delay=0.0)
+    ctx = _retry_context(tags={TAG_READONLY})
+
+    async def real_call_next(_context: t.Any) -> t.Any:
+        return list_sessions(socket_name="retry-skip-smoke")
+
+    with pytest.raises(ToolError):
+        asyncio.run(middleware.on_call_tool(ctx, real_call_next))
+
+    assert calls["count"] == 1, (
+        f"a missing object was retried (calls={calls['count']}). The skip must "
+        f"walk __cause__, because handle_tool_errors wraps it in ExpectedToolError."
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -875,6 +875,8 @@ def test_handle_tool_errors_async_wraps_unexpected_exception() -> None:
         exc.TmuxSessionExists("session foo already exists"),
         exc.BadSessionName("bad name"),
         exc.TmuxObjectDoesNotExist("@99"),
+        exc.ObjectDoesNotExist(query={"window_name": "gone"}),
+        exc.MultipleObjectsReturned(count=2, query={"pane_id": "%0"}),
         exc.PaneNotFound("%99"),
         exc.LibTmuxException("server gone"),
     ],
@@ -952,6 +954,10 @@ def test_expected_tool_error_logs_warning_through_server(
     ("raised", "expected_suggestion_fragment"),
     [
         (exc.TmuxObjectDoesNotExist("@99"), "list_sessions / list_windows"),
+        (
+            exc.MultipleObjectsReturned(count=2, query={"pane_id": "%0"}),
+            "Target it by id",
+        ),
         (exc.PaneNotFound("%99"), "list_panes"),
         (exc.TmuxSessionExists("dup"), None),
         (exc.BadSessionName("bad:name"), None),

--- a/uv.lock
+++ b/uv.lock
@@ -1176,11 +1176,11 @@ wheels = [
 
 [[package]]
 name = "libtmux"
-version = "0.61.0"
+version = "0.62.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/c2/6abbac4420c35b3f1140c72607117236b160173f74fd86941f99b28375d5/libtmux-0.61.0.tar.gz", hash = "sha256:2d6081081a629b9236a36a64f874667533811d2ce5a1b0caa9c821f4d9d2e618", size = 546122, upload-time = "2026-07-04T12:57:36.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/b8/0410c8487f7673926d141a5aaaf60133984a564b3c90eb4f3f99e92e7740/libtmux-0.62.0.tar.gz", hash = "sha256:41e9e80602b2656fd119b13253b27bad46af5cfef32099be53cdd391e2936b61", size = 571757, upload-time = "2026-07-12T21:48:02.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/14/934d0d9076d1d46fcc71f3397daea7921363781674337084b15d1bbcbf84/libtmux-0.61.0-py3-none-any.whl", hash = "sha256:b9315db6600757f840a8f16438725103e579aaa4be3c32728c105f2c284330df", size = 118059, upload-time = "2026-07-04T12:57:34.598Z" },
+    { url = "https://files.pythonhosted.org/packages/87/96/471ac01844ee157fe794446e17568e9bf219d323575c2acc7957a9a2d8c9/libtmux-0.62.0-py3-none-any.whl", hash = "sha256:626aa6fae45e3a423e1acc81604efafa63b7262b1d67b2c7a8778b1ad691456b", size = 127700, upload-time = "2026-07-12T21:48:01.52Z" },
 ]
 
 [[package]]
@@ -1244,7 +1244,7 @@ testing = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.4.2,<4.0.0" },
-    { name = "libtmux", specifier = ">=0.61.0,<1.0" },
+    { name = "libtmux", specifier = ">=0.62.0,<1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
**Draft — do not merge with the git pin in place.** Validates [tmux-python/libtmux#718](https://github.com/tmux-python/libtmux/pull/718) downstream before it ships. Drop the `[tool.uv.sources]` stanza and bump the `libtmux` floor once #718 is released.

Fixes #97 (the ambiguous-lookup half).

## Why

libtmux#718 moves `MultipleObjectsReturned` and `ObjectDoesNotExist` under `LibTmuxException` — and `TmuxObjectDoesNotExist` inherits from `ObjectDoesNotExist`, so it moves too. This server keys two behaviours off `LibTmuxException`, and both change silently.

**The suite did not notice.** Pinned to the #718 branch, `main` is green: **701 passed, 0 failed.** Every changed path was uncovered. That is the finding, and it is why this PR leads with tests.

## What was broken

**1. A stale id was retried.** `ReadonlyRetryMiddleware` retries on `LibTmuxException`, which is correct for the transient socket errors libtmux wraps — but most of that family is not transient. A pane that does not exist will not exist on the second look; an ambiguous match does not become unambiguous during a backoff window. Every readonly call carrying a stale or guessed id paid **a second tmux round-trip and 100 ms of latency to fail identically** — and because `AuditMiddleware` sits outside the retry, the audit log recorded one call, so the doubled traffic was invisible.

This is **not new with #718.** `_resolve_pane` raises `PaneNotFound`, which is *already* a `LibTmuxException` — so panes have been over-retried all along. #718 merely widens it to every missing session and window, which is what made it impossible to keep ignoring. The fix closes the whole family, including the part that was already broken:

```
tests/test_middleware.py::test_readonly_retry_skips_deterministic_failures
  [TmuxObjectDoesNotExist]   FAILED on main   <- new with #718
  [MultipleObjectsReturned]  FAILED on main   <- new with #718
  [PaneNotFound]             FAILED on main   <- pre-existing
  [NoWindowsExist]           FAILED on main   <- pre-existing
  [BadSessionName]           FAILED on main   <- pre-existing
  [TmuxSessionExists]        FAILED on main   <- pre-existing
```

**2. An ambiguous target reached the agent with no way forward.** A window shared between sessions (a grouped session, or `link-window`) is listed once per session that holds it, so a name or index can match several rows and the lookup raises `MultipleObjectsReturned`. Today that surfaces as `Unexpected error: MultipleObjectsReturned:` with an empty message and a stack trace. Under #718 it would land somewhere worse: reclassified as *agent-correctable* (`expected: true`, WARNING, `"tmux error: …"`) **while still saying nothing about how to correct it**. It now names the fix — target the object by id.

## The fix

- `NON_RETRYABLE_EXCEPTIONS` in `middleware.py`, skipped in the retry decision. The check walks `__cause__` one hop, exactly as fastmcp's `_should_retry` does — necessary because `handle_tool_errors` re-raises every libtmux failure as an `ExpectedToolError` chained off the original, so at the middleware layer the real failure is only visible one hop down.
- An explicit `MultipleObjectsReturned` arm in `_map_exception_to_tool_error`, above the `LibTmuxException` arm, carrying a recovery suggestion.
- The not-found arm widened from `TmuxObjectDoesNotExist` to `ObjectDoesNotExist`, so a `QueryList` miss gets the same discovery hint as a tmux-id miss.

## Verification

Every new test **fails on `main` and passes here** — proven by reverting `src/` and re-running:

```
src/ = main   ->  8 failed
src/ = fixed  ->  all pass
```

`ruff format` · `pytest` · `ruff check --fix` · `mypy` (strict) · `just build-docs` — all green. **711 passed** (was 701).

The end-to-end test (`test_readonly_retry_skips_not_found_on_decorated_tool`) drives the real `list_sessions` tool through the production middleware stack, so it exercises the `handle_tool_errors` → `__cause__` → retry-decision chain rather than a unit stub. A unit test alone would pass even if the skip never fired in production.

## Before merge

1. libtmux#718 ships.
2. Drop `[tool.uv.sources]` from `pyproject.toml`.
3. Bump the floor: `libtmux>=<that release>,<1.0` (was `>=0.61.0`).
4. `uv lock`, re-run the gates.
