### PR TITLE
Add MCP CLI-testing skill and mcp_swap doctor/--env

### DIFF
--- a/.agents/skills/testing-mcp-with-cli-agents/SKILL.md
+++ b/.agents/skills/testing-mcp-with-cli-agents/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: testing-mcp-with-cli-agents
+description: >-
+  Test an MCP server by driving real CLI agents (Claude, Codex, Cursor, Gemini,
+  Grok, agy) against it, using isolated tmux sockets and send-keys instead of
+  trusting unit tests alone. Use this whenever verifying MCP-server behavior
+  end-to-end, checking that a local branch or checkout works across installed
+  agent CLIs, comparing trunk-vs-branch MCP behavior, driving an interactive
+  agent TUI to exercise approval flows or cancellation, reproducing a tmux-MCP
+  bug through a live client, or wiring a checkout into the CLIs with mcp_swap.
+  Reach for it even when the user only says "test the MCP", "does the branch
+  work in the agents", "drive the CLI to call the tool", or "check it across
+  Codex/Gemini/Cursor" without naming tmux or sockets explicitly.
+---
+
+# Testing an MCP server through real CLI agents
+
+Unit tests prove the server's internals; they don't prove a real agent can
+discover a tool, get past its approval gate, call it, and survive cancelling it
+mid-flight. This skill exercises that whole path by pointing installed CLI
+agents at a checkout and driving them — with the tmux tool surface (libtmux-mcp)
+as the running example, though the shape generalizes to any MCP server.
+
+## The core idea: three tmux servers, never one
+
+The single biggest mistake is running everything on one tmux socket. Keep three
+distinct servers, each on its own socket, and the whole thing becomes safe and
+observable:
+
+| Role | Socket | Who touches it | Why separate |
+|---|---|---|---|
+| Your real session | default | you, interactively | must never be mutated by a test |
+| Harness | `tmux -L cli-harness` | the driver: `send-keys` prompts in, `capture-pane` render out | isolates the CLI TUI you're driving |
+| MCP-target | `tmux -L mcp-target`, exported as `LIBTMUX_SOCKET=mcp-target` to the server | the MCP server, when the agent calls tmux tools | independent ground-truth; a destructive tool here can't kill the agent you're driving |
+
+The server resolves its socket from `LIBTMUX_SOCKET` and runs `tmux -L <name>`
+(`src/libtmux_mcp/_utils.py` builds argv with `-L server.socket_name`, defaulted
+from that env var). Exporting `LIBTMUX_SOCKET=mcp-target` into the server's
+config env fully sandboxes every tmux tool call onto a scratch server.
+Pre-create it so the agent has something to see:
+
+```console
+$ tmux -L mcp-target new-session -d -s scratch
+```
+
+Keeping **harness** separate from **MCP-target** is the load-bearing part: if the
+agent's own TUI pane lived on the socket its MCP server mutates, one
+`kill-server` / `kill-session` tool call would tear down the agent mid-test, and
+your captures would be polluted by the agent's own UI redraws.
+
+## Climb only as high as the question needs — three fidelity layers
+
+### Layer 0 — Direct MCP smoke, no CLI at all
+
+Fastest and most deterministic. Drive the server over stdio from a tiny FastMCP
+client against an isolated socket and assert the wire contract directly: the
+tool list, a couple of representative calls, an error path. Use this to answer
+"is the tool surface and result shape correct?" before spending a CLI on it.
+
+Shape-normalization gotchas seen in practice — normalize before asserting:
+- Match the current `LIBTMUX_SAFETY` tier: destructive-batch wrappers are hidden
+  at the default tier, so don't assert they're visible.
+- List-returning tools surface `structuredContent` as `{"result": [...]}`;
+  `capture_pane` output can come back under `result` as a string. Don't assume a
+  top-level `count`.
+
+### Layer 1 — Headless CLI one-shot
+
+Proves the real client can discover and call the tools, scriptably, with no
+send-keys. Every CLI has a non-interactive mode. Registration-proof commands are
+cheaper than a full prompt; run those first. Flags drift between releases — the
+matrix in `references/cli-matrix.md` lists last-known-good invocations and the
+per-CLI traps (e.g. `cursor-agent mcp list` under-reports; use `mcp list-tools`).
+Re-verify with `--help` before trusting any flag.
+
+### Layer 2 — Interactive, driven by tmux send-keys
+
+The high-fidelity path, and the only one that exercises approval flows, live
+streaming, multi-turn, and cancellation. The loop:
+
+```console
+# 1. launch the agent TUI in a WIDE harness pane (so TUI text isn't wrapped)
+$ tmux -L cli-harness new-session -d -s codex -x 220 -y 50
+$ tmux -L cli-harness send-keys -t codex 'cd /repo && LIBTMUX_SOCKET=mcp-target codex' Enter
+
+# 2. wait for the prompt to render, THEN type — never type blind
+$ tmux -L cli-harness capture-pane -p -t codex | tail -5     # poll until ready
+$ tmux -L cli-harness send-keys -t codex 'Use the tmux MCP to create a window named probe, then list windows' Enter
+
+# 3. handle the approval gate — the #1 hang source (see below)
+$ tmux -L cli-harness send-keys -t codex 'y' Enter           # or the mapped key
+
+# 4. observe what the AGENT rendered (harness socket)
+$ tmux -L cli-harness capture-pane -p -t codex | tail -30
+
+# 5. assert GROUND TRUTH independently (mcp-target socket)
+$ tmux -L mcp-target list-windows -t scratch                 # expect a 'probe' window
+```
+
+Step 5 is the whole point: it separates *"the agent said it worked"* from *"the
+tool actually mutated tmux."* Layers 0 and 1 can be fooled by a hallucinated
+success line; the target socket cannot.
+
+## Two failure modes that waste the most time
+
+**Approval gates hang naive harnesses.** The first tool use pops an approval
+dialog. A driver that types the prompt and immediately waits for output waits
+forever. Either pre-approve with the CLI's trust/approval flags (see the
+matrix), or detect the approval prompt via `capture-pane` and answer its
+keystroke *before* waiting for the result.
+
+**Sleeping instead of waiting is flaky.** Poll `capture-pane` for a stable
+completion marker — the prompt glyph returning, a known output line — rather than
+`sleep N`. If you drive with libtmux-mcp itself, `wait_for_text` with a `stop`
+list is the right primitive, but point it at the *harness* socket, never the
+server under test.
+
+## High-value test: cancellation / teardown
+
+Cancellation is invisible to the tool list and only reachable through Layer 2 —
+and it is exactly where tmux-MCP servers leak. Reproduce it:
+
+1. Prompt the agent to call a `wait_for_text` that will never match (long timeout).
+2. Once it's mid-call, cancel: `send-keys -t <pane> C-c`, or kill the pane.
+3. On the **mcp-target** socket, assert no orphaned `tmux`/child process survives
+   (`pgrep -f mcp-target`) and the server exits promptly.
+
+A server that reaps its child on cancel passes; one that orphans it hangs
+interpreter shutdown. This is a behavioral difference you cannot see from schemas.
+
+## Comparing two versions (trunk vs a branch)
+
+Two worktrees, two target sockets, same prompt:
+
+```console
+$ git worktree add ../mcp-trunk  origin/main
+$ git worktree add ../mcp-branch <branch>
+# point one CLI's config at ../mcp-trunk  (LIBTMUX_SOCKET=mcp-trunk)
+# point another at ../mcp-branch (LIBTMUX_SOCKET=mcp-branch)
+```
+
+Diff three things: the **tool surface** (`mcp list-tools` or a Layer-0 tool dump,
+diffed), the **rendered agent behavior** for the same prompt (capture-pane
+transcripts), and the **ground-truth socket state** after the run.
+
+## Wiring a checkout into the CLIs: mcp_swap
+
+`scripts/mcp_swap.py` rewrites each CLI's config to `uv --directory <repo> run
+<entry>` and preserves existing env on replacement:
+
+```console
+$ uv run scripts/mcp_swap.py detect                        # which CLIs are present
+$ uv run scripts/mcp_swap.py status --server tmux           # current entries
+$ uv run scripts/mcp_swap.py use-local --server tmux --dry-run
+$ uv run scripts/mcp_swap.py use-local --server tmux
+$ uv run scripts/mcp_swap.py revert                         # restore from timestamped backups
+```
+
+Repo-specific traps live in `references/cli-matrix.md` — read it before running a
+swap. The short version: pass `--server tmux` (the real registration key on this
+machine is `tmux`, not the derived `libtmux`); mcp_swap preserves env but does
+not add new keys, so inject `LIBTMUX_SOCKET=mcp-target` via each CLI's native
+`mcp add ... -e ...` or a post-swap edit; `mcp_swap use-local` mutates the user's
+real CLI configs, so dry-run first and always `revert` at the end.
+
+## Cleanup checklist
+
+```console
+$ tmux -L cli-harness kill-server 2>/dev/null
+$ tmux -L mcp-target  kill-server 2>/dev/null
+$ uv run scripts/mcp_swap.py revert
+```
+
+Scratch sockets vanish with their server; configs restore from mcp_swap's
+timestamped backups (LIFO if multiple swaps stacked).
+
+## When NOT to reach for the full harness
+
+If the question is purely "is the tool surface correct?" or "does this result
+shape parse?", stay at Layer 0 — booting six CLIs to answer a wire-contract
+question is wasted effort. Escalate to Layers 1 and 2 only when the client's
+discovery, approval, streaming, or cancellation behavior is what's actually in
+doubt.

--- a/.agents/skills/testing-mcp-with-cli-agents/SKILL.md
+++ b/.agents/skills/testing-mcp-with-cli-agents/SKILL.md
@@ -67,11 +67,16 @@ Shape-normalization gotchas seen in practice — normalize before asserting:
 ### Layer 1 — Headless CLI one-shot
 
 Proves the real client can discover and call the tools, scriptably, with no
-send-keys. Every CLI has a non-interactive mode. Registration-proof commands are
-cheaper than a full prompt; run those first. Flags drift between releases — the
-matrix in `references/cli-matrix.md` lists last-known-good invocations and the
-per-CLI traps (e.g. `cursor-agent mcp list` under-reports; use `mcp list-tools`).
-Re-verify with `--help` before trusting any flag.
+send-keys. Every CLI has a non-interactive mode. A cheap discovery proof (does
+the client *see* the server?) is worth running before spending a model turn —
+but the cheapest proof differs sharply per CLI: grok's `mcp doctor` does a real
+handshake, codex's `mcp get` only parses config, and agy has no proof short of a
+model call. `references/cli-matrix.md` has the verified per-CLI invocation,
+isolation lever, and approval-bypass flag for all six. Two things that surprise
+people: some `mcp list`/`list-tools` subcommands read the *ambient* config and
+ignore your isolated one, and a mutating tool call needs a per-CLI
+approval-bypass flag or it hangs on a no-TTY prompt. Flags drift — re-verify with
+`--help`.
 
 ### Layer 2 — Interactive, driven by tmux send-keys
 
@@ -115,15 +120,30 @@ completion marker — the prompt glyph returning, a known output line — rather
 list is the right primitive, but point it at the *harness* socket, never the
 server under test.
 
+**Submit as separate events.** Send the prompt text and `Enter` as two distinct
+`send-keys` calls — then one Enter submits. Batching text and `Enter` into a
+single `send-keys` is what leaves the prompt sitting unsent and makes it look
+like you need a second Enter. Also mind PATH: a CLI launched inside a `-L`
+harness pane runs in a non-login shell that lacks your mise/node/uv shims, so
+`export` the needed bin dirs before launching it or you'll just get `command not
+found`.
+
 ## High-value test: cancellation / teardown
 
 Cancellation is invisible to the tool list and only reachable through Layer 2 —
 and it is exactly where tmux-MCP servers leak. Reproduce it:
 
 1. Prompt the agent to call a `wait_for_text` that will never match (long timeout).
-2. Once it's mid-call, cancel: `send-keys -t <pane> C-c`, or kill the pane.
+2. While it's mid-call — the TUI shows a "working / esc to interrupt" state — send
+   `Escape` to that pane. `Esc` during the working phase cancels the in-flight
+   tool call **while keeping the MCP server subprocess alive**, which is the exact
+   client-cancellation the reap path guards; `Esc` *after* a turn finishes just
+   enters edit-previous mode. (Killing the pane instead tears down the whole
+   server, which tests a different thing.)
 3. On the **mcp-target** socket, assert no orphaned `tmux`/child process survives
-   (`pgrep -f mcp-target`) and the server exits promptly.
+   (`pgrep -f mcp-target`) and the server stays healthy. Verified through Codex:
+   the `wait_for_text` call returned `Error: interrupted`, the server survived,
+   and no child leaked.
 
 A server that reaps its child on cancel passes; one that orphans it hangs
 interpreter shutdown. This is a behavioral difference you cannot see from schemas.
@@ -156,12 +176,22 @@ $ uv run scripts/mcp_swap.py use-local --server tmux
 $ uv run scripts/mcp_swap.py revert                         # restore from timestamped backups
 ```
 
-Repo-specific traps live in `references/cli-matrix.md` — read it before running a
-swap. The short version: pass `--server tmux` (the real registration key on this
+The short version: pass `--server tmux` (the real registration key on this
 machine is `tmux`, not the derived `libtmux`); mcp_swap preserves env but does
 not add new keys, so inject `LIBTMUX_SOCKET=mcp-target` via each CLI's native
 `mcp add ... -e ...` or a post-swap edit; `mcp_swap use-local` mutates the user's
 real CLI configs, so dry-run first and always `revert` at the end.
+
+**Prefer zero-mutation isolation for a test.** mcp_swap is for a swap you *want*
+to persist. To just exercise a checkout, use each CLI's throwaway config-home /
+project-config lever instead — `references/cli-matrix.md` gives the verified one
+per CLI (codex `CODEX_HOME` or `-c` overrides, grok `GROK_HOME`, agy
+`--gemini_dir`, cursor/gemini project config, claude `--mcp-config
+--strict-mcp-config`). All six were driven this way with their real config
+confirmed byte-identical afterward, and no swap state touched. Note the machine
+may already carry an un-reverted swap (all CLIs pointing at a local checkout), so
+`revert` returns you to *that* state, not a pristine one — check the swap state
+file before assuming.
 
 ## Cleanup checklist
 

--- a/.agents/skills/testing-mcp-with-cli-agents/SKILL.md
+++ b/.agents/skills/testing-mcp-with-cli-agents/SKILL.md
@@ -170,11 +170,18 @@ transcripts), and the **ground-truth socket state** after the run.
 
 ```console
 $ uv run scripts/mcp_swap.py detect                        # which CLIs are present
+$ uv run scripts/mcp_swap.py doctor --server tmux           # effective environment + footguns
 $ uv run scripts/mcp_swap.py status --server tmux           # current entries
-$ uv run scripts/mcp_swap.py use-local --server tmux --dry-run
-$ uv run scripts/mcp_swap.py use-local --server tmux
+$ uv run scripts/mcp_swap.py use-local --server tmux --env LIBTMUX_SOCKET=mcp-target --dry-run
+$ uv run scripts/mcp_swap.py use-local --server tmux --env LIBTMUX_SOCKET=mcp-target
 $ uv run scripts/mcp_swap.py revert                         # restore from timestamped backups
 ```
+
+Run `doctor` first — it reports which server name each CLI points at (and warns
+when the repo is registered under a name other than the derived default),
+un-reverted swaps and orphaned backups, missing backups (revert would fail), and
+auth-overriding env vars like `OPENAI_API_KEY`. `--env` injects the isolated
+`LIBTMUX_SOCKET` into the entry at swap time, so you don't hand-edit the config.
 
 The short version: pass `--server tmux` (the real registration key on this
 machine is `tmux`, not the derived `libtmux`); mcp_swap preserves env but does

--- a/.agents/skills/testing-mcp-with-cli-agents/references/cli-matrix.md
+++ b/.agents/skills/testing-mcp-with-cli-agents/references/cli-matrix.md
@@ -1,85 +1,145 @@
-# CLI matrix — last-known-good invocations and per-CLI traps
+# CLI matrix — per-CLI isolation, proofs, and gotchas
 
-Flags drift between releases. Treat everything here as last-known-good and
-re-verify with `<cli> --help` / `<cli> mcp --help` before trusting it. Sourced
-from verified prior QA runs against libtmux-mcp and agentgrep-mcp.
+Verified 2026-07-24 by driving all six CLIs against a branch libtmux-mcp server on
+isolated tmux sockets, each with a throwaway config. **Every real config was
+confirmed byte-identical before/after** — no CLI needs `mcp_swap` or a real-config
+write to be tested. Full model-driven tool-call proof (agent calls a tool, isolated
+socket confirms the mutation) was reached on **codex, cursor, grok, agy**; **claude**
+and **gemini** were blocked at account tier/credit, not by the harness. Flags drift —
+re-verify with `<cli> --help` before trusting any invocation below.
 
-## Registration proofs (cheapest — run before spending a full prompt)
+## Cross-cutting lessons (the transferable part)
 
-```console
-$ claude mcp list;         claude mcp get tmux
-$ codex mcp list;          codex mcp get tmux
-$ gemini mcp list
-$ cursor-agent mcp list-tools tmux      # NOT `mcp list` — see trap below
-```
+1. **Isolate the config, never mutate it.** Every CLI exposes a config-home or
+   project-config lever (table below). None requires `mcp_swap` for a test.
+2. **The wall is auth/account tier, not the harness.** claude → `Credit balance is
+   too low`; gemini → `IneligibleTierError` (free tier unsupported). Treat these as
+   findings and stop spending; they are not harness failures.
+3. **Name the throwaway server distinctively (`tmuxlab`, not `tmux`).** All six CLIs
+   already carry a `tmux` server (from a prior swap) pointing at the real checkout on
+   the default socket. An identical name silently collides — it merges (cursor),
+   shadows (gemini), or gets resolved instead of yours (claude `mcp list`). A unique
+   name makes any leakage obvious.
+4. **Config leaks across CLIs.** grok merges Claude Code's `~/.claude.json` *and* any
+   cwd `.mcp.json` into its own MCP set; agy and gemini share the `~/.gemini` tree;
+   codex's daemon is keyed to `CODEX_HOME` (so a throwaway home spawns an independent
+   process tree — no conflict). Assume ambient servers are present unless you override
+   `HOME`/config-home fully.
+5. **"Cheapest proof" is not uniform.** grok's `mcp doctor` does a *real handshake*
+   (reported 51 tools — matches the branch surface); codex's `mcp get` only *parses
+   config*; agy has nothing short of a model call. Pick per CLI (table).
+6. **PATH:** for a **headless** run, export the node + uv dirs once before invoking —
+   the CLI inherits them and launches the `uv` server fine. The alternate-socket-pane
+   PATH gap (a `-L` pane's non-login shell lacks the mise shims) only bites when you
+   launch a CLI **TUI inside a harness pane** (Layer 2).
+7. **Non-interactive mutating tool calls need an approval-bypass flag** — different per
+   CLI (table). Without it, a mutating call blocks on an approval prompt with no TTY
+   and the harness hangs.
+8. **Interactive send-keys submit:** send the prompt text and `Enter` as **separate
+   `send-keys` events** — then a single Enter submits. The "needs a double Enter"
+   pitfall comes from batching text+Enter in one `send-keys` call. `Esc` cancels only
+   **during** the working/tool phase; after a turn completes it enters edit-previous
+   mode instead.
 
-## Headless one-shot (Layer 1)
+## Quick matrix
 
-```console
-$ codex -a never exec --sandbox read-only --json -C /repo \
-    'Call the tmux MCP: list sessions and report the count.'
+| CLI | headless one-shot | config-isolation lever | cheapest discovery proof | approval bypass (non-interactive) | full model proof reached |
+|---|---|---|---|---|---|
+| claude | `claude -p` | `--mcp-config <f> --strict-mcp-config` (session only) | `-p --output-format stream-json` init event | `--permission-mode bypassPermissions` | no — credit blocked |
+| codex | `codex exec` | `CODEX_HOME` throwaway **or** `-c` overrides | `codex mcp get tmux` (parses config, no spawn) | `--dangerously-bypass-approvals-and-sandbox` | yes |
+| cursor | `cursor-agent --print` | project `.cursor/mcp.json` (merged, not isolating) | headless `--approve-mcps` run (see trap) | `--force --approve-mcps` (omit `--mode`) | yes |
+| gemini | `gemini -p` | project `.gemini/settings.json` from cwd | `gemini mcp list` | `--approval-mode yolo` (`--skip-trust`) | no — free tier |
+| grok | `grok -p` / `--single` | `GROK_HOME` **or** `mcp add --scope project` | `grok mcp doctor tmux --json` (real handshake) | `--permission-mode bypassPermissions` | yes |
+| agy | `agy -p` | hidden `--gemini_dir <path>` | none short of a model call | `--dangerously-skip-permissions` | yes |
 
-$ gemini --skip-trust --allowed-mcp-server-names tmux --approval-mode yolo \
-    --output-format json -p 'Call the tmux MCP: list sessions.'
+## Per-CLI detail
 
-$ cursor-agent --print --output-format stream-json --trust --approve-mcps \
-    --sandbox enabled --mode ask --workspace /repo \
-    'Call the tmux MCP: list sessions.'
-```
+### codex — two isolation styles, both verified
+- **Config-less (leanest):** a home dir containing only a symlink to real `auth.json`,
+  no `config.toml`, plus `-c` overrides:
+  `-c 'mcp_servers.tmux.command="uv"' -c 'mcp_servers.tmux.args=["--directory","<SERVER>","run","libtmux-mcp"]' -c 'mcp_servers.tmux.env.LIBTMUX_SOCKET="mcplab-codex-target"'`.
+  Nothing to copy or diff back.
+- **Copy-config:** `cp ~/.codex/config.toml <home>/`; symlink `auth.json`; rewrite
+  `[mcp_servers.tmux]`. Downside: **drags in the user's hooks/output-style**, which
+  fire in the isolated session — prefer the `-c` style.
+- Run: `env -u OPENAI_API_KEY CODEX_HOME=<home> codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check -C <SERVER> '<prompt>'`.
+- Gotchas: **`OPENAI_API_KEY` in the env hijacks auth** to API-key billing even with a
+  ChatGPT `auth.json` — always `env -u OPENAI_API_KEY` to use the subscription. **No
+  `codex mcp list-tools`** exists; `mcp list`/`get`/`doctor` only count/parse config —
+  real tool enumeration needs a model turn. Subcommand flags are position-sensitive
+  (`--ignore-user-config`/`--skip-git-repo-check` go *after* the subcommand;
+  `--skip-git-repo-check` is exec-only). `LIBTMUX_SOCKET` shows masked as `*****` in
+  `mcp get`. The `/tmp` `CODEX_HOME` helper-binary warning prints on every subcommand —
+  harmless.
 
-Claude headless: `claude -p '<prompt>'` (add MCP scope/permission flags as your
-setup requires). Grok and agy follow the interactive (Layer 2) path unless a
-current `--help` shows a print/exec mode.
+### cursor — full success, and it CORRECTS prior art
+- Project `<ws>/.cursor/mcp.json` with a **distinct** server name (`tmuxlab`); run with
+  cwd=`<ws>` or `--workspace <ws>`:
+  `cursor-agent --print --output-format stream-json --trust --approve-mcps --force --workspace <ws> '<prompt naming the tmuxlab tool>'`.
+- **CORRECTION:** the old note "`mcp list-tools` returns tools even when `mcp list` says
+  needs-approval" is **reversed** on build 2026.07.23 — `mcp list-tools <unapproved>`
+  now *fails* (`has not been approved`), and `--approve-mcps` on the `mcp` subcommand
+  doesn't help. Prove via a headless `--approve-mcps` agent run + the socket, not
+  `list-tools`.
+- **CORRECTION:** `--mode ask`/`--mode plan` are **read-only**, so a mutating call is
+  suppressed. Omit `--mode` (default agent mode) and add `--force`.
+- Project config is **merged** with global (all global servers still load) — isolate by
+  unique name + `env.LIBTMUX_SOCKET`, not by expecting the project file to override.
+  No `mcp add`; config is a JSON file only.
 
-## Per-CLI traps
+### grok — full success, best cheap proof
+- `GROK_HOME=<ws>/.grok grok mcp add tmux -e LIBTMUX_SOCKET=mcplab-grok-target -- uv --directory <SERVER> run libtmux-mcp`, then
+  `cp ~/.grok/auth.json ~/.grok/agent_id <ws>/.grok/` (**auth does not follow
+  `GROK_HOME`**), then
+  `GROK_HOME=<ws>/.grok grok -p '<prompt>' --permission-mode bypassPermissions --cwd <ws> --output-format plain`.
+- `grok mcp doctor tmux --json` is the **best cheap proof of any CLI** — a real
+  handshake reporting tool count, no model turn. Alternative isolation: `mcp add
+  --scope project` writes `./.grok/config.toml` (keeps real `$HOME`/auth).
+- Gotchas: **grok merges `~/.claude.json` + cwd `.mcp.json`** into its server set, so
+  `GROK_HOME` alone doesn't fully isolate — override `HOME` for a clean set. `grok
+  models` says "not authenticated" even when auth is valid (misleading banner; trust
+  `doctor` and the run). `mcp add` prints the literal `$GROK_HOME` (cosmetic).
 
-- **cursor-agent `mcp list` under-reports.** It can say `not loaded (needs
-  approval)` while `cursor-agent mcp list-tools tmux` returns the full list and
-  Composer calls the tools fine. `list-tools` + one real call is the
-  authoritative proof, not the status string.
-- **Codex approval-flag placement.** Use the top-level form `codex -a never
-  exec ...`; passing the approval policy *after* `exec` fails.
-- **Claude account state can block headless runs** (`Credit balance is too
-  low`). That's a client/account limit, not a server bug — fall back to Layer 2
-  or Layer 0.
-- **Claude worktree scope shadowing.** Claude maps a linked git worktree to the
-  main worktree path for per-project MCP, so a per-project entry can out-rank a
-  `--scope user` swap. Know which layer you're actually hitting with `claude mcp
-  get`.
+### agy (Antigravity) — full success, no `mcp` verb
+- **Hidden `--gemini_dir <path>`** flag (not in `--help`; `agy --gemini_dir` errors
+  "flag needs an argument", confirming it) relocates the entire `~/.gemini` tree —
+  cleaner than a `HOME` override. Symlink the real auth/state files
+  (`oauth_creds.json`, `google_account_id`, `installation_id`, `settings.json`, …)
+  into `<gdir>`, but make `<gdir>/config/mcp_config.json` your own
+  `{"mcpServers":{"tmux":{...,"env":{"LIBTMUX_SOCKET":"mcplab-agy-target"}}}}`.
+- Run: `PATH=<uv>:<node>:$PATH agy --gemini_dir <gdir> --log-file <log> --dangerously-skip-permissions --print-timeout 3m -p '<prompt>'`.
+- Gotchas: **no `mcp` verb at all** — MCP is configured only by editing
+  `mcp_config.json`, and the *only* way to enumerate/exercise tools is a model call.
+  `--gemini_dir` does **not** isolate auth (symlink it in). Headless needs
+  `--dangerously-skip-permissions` (or `--mode accept-edits`). `--print-timeout`
+  default is 5m — set it low and wrap in an outer `timeout`.
 
-## Native `mcp add` (per CLI) — for injecting env like LIBTMUX_SOCKET
+### claude — isolation proven, model turn credit-blocked
+- `--mcp-config <file> --strict-mcp-config` fully scopes which MCP servers a
+  `-p`/interactive **session** sees (the `init` event lists only your server) — but the
+  server sits at `status:"pending"` and connects lazily on the **first model turn**, so
+  you can't enumerate its tools without spending one.
+- **`claude mcp list`/`get` ignore `--mcp-config`** and inspect the *ambient* config —
+  not usable for isolated discovery. Use a `-p --output-format stream-json` run and read
+  the `init` event's `mcp_servers` array.
+- `--strict-mcp-config` scopes MCP **only**: a `-p` run still **writes `~/.claude.json`**
+  (it grew) and creates `~/.claude/projects/<cwd>/`, and ambient hooks/skills/plugins
+  fire. Add **`--bare`** to strip hooks/auto-memory/keychain/CLAUDE.md and minimize
+  ambient writes. `mcp list` alone leaves `~/.claude.json` untouched.
+- Auth: `ANTHROPIC_API_KEY` (if set) takes precedence over the claude.ai OAuth login;
+  `env -u ANTHROPIC_API_KEY claude …` forces subscription auth. Here the API key's
+  account returned `Credit balance is too low` — model turn blocked.
 
-mcp_swap preserves existing env but does not add new keys, so to sandbox the
-socket use each CLI's own add command (syntax varies; the `-e` / `--env`
-placement is the usual footgun):
-
-```console
-$ claude mcp add tmux -s user -e LIBTMUX_SOCKET=mcp-target -- uv --directory /repo run libtmux-mcp
-$ codex  mcp add tmux --env LIBTMUX_SOCKET=mcp-target       -- uv --directory /repo run libtmux-mcp
-$ gemini mcp add tmux -s user -e LIBTMUX_SOCKET=mcp-target  uv -- --directory /repo run libtmux-mcp
-$ grok   mcp add tmux -e LIBTMUX_SOCKET=mcp-target          -- uv --directory /repo run libtmux-mcp
-```
-
-Cursor and agy have no `mcp add` — edit their JSON config directly
-(`~/.cursor/mcp.json`, `~/.gemini/config/mcp_config.json`) with the same
-`command` / `args` / `env` shape, then approve in-app.
-
-## mcp_swap traps (this repo)
-
-- **Pass `--server tmux`.** The script derives the slug `libtmux` from the
-  package name, but the effective registered key on this machine is `tmux`.
-  Without the flag you swap a `libtmux` entry nobody uses — `status` with no flag
-  reports `no entry for 'libtmux'` across all six CLIs.
-- **`--entry` when the first `[project.scripts]` key isn't the MCP entry.** Here
-  the only script is `libtmux-mcp`, so the default is fine; other repos (e.g.
-  agentgrep needed `--entry agentgrep-mcp`) do not get that for free.
-- **`use-local` mutates real user configs.** Dry-run first; `revert` unwinds from
-  timestamped backups in LIFO order when swaps stack.
-
-## Direct-smoke sanity values (Layer 0, libtmux-mcp)
-
-A healthy default-tier smoke against an isolated socket has looked like: `~52`
-tools visible, `list_sessions` works, `call_readonly_tools_batch` works,
-`send_keys_batch` preserves op order, and an oversized batch is rejected with
-`operations must contain at most 1000 tool calls`. Exact tool count shifts as the
-surface evolves — treat these as a shape check, not a fixed assertion.
+### gemini — isolation proven, model turn tier-blocked
+- Project `<ws>/.gemini/settings.json` (`{"mcpServers":{"tmux":{"command","args","env"}}}`)
+  read from **cwd**; a project-scoped server **shadows** a same-named user server (real
+  `settings.json` stays clean). `gemini mcp add <name> <cmd> [args] -s project -e K=V`
+  defaults to project scope.
+- Run: `gemini --skip-trust --allowed-mcp-server-names tmux --approval-mode yolo --output-format json -p '<prompt>'` (verified against gemini 0.52.0).
+- Gotchas: **untrusted folders disable ALL MCP** — `mcp list` shows every server
+  `Disabled`; pass `--skip-trust` on the run (`mcp list` has no such flag, so its
+  Disabled output is expected, not a failure). A failed headless run **still mutates
+  `~/.gemini/projects.json`** (appends the cwd) — project config does not stop that
+  global-registry write; full isolation needs a `HOME`/config-dir override (which
+  discards real OAuth). Auth: `IneligibleTierError` free-tier — no model turn on this
+  account/CLI version.

--- a/.agents/skills/testing-mcp-with-cli-agents/references/cli-matrix.md
+++ b/.agents/skills/testing-mcp-with-cli-agents/references/cli-matrix.md
@@ -1,0 +1,85 @@
+# CLI matrix — last-known-good invocations and per-CLI traps
+
+Flags drift between releases. Treat everything here as last-known-good and
+re-verify with `<cli> --help` / `<cli> mcp --help` before trusting it. Sourced
+from verified prior QA runs against libtmux-mcp and agentgrep-mcp.
+
+## Registration proofs (cheapest — run before spending a full prompt)
+
+```console
+$ claude mcp list;         claude mcp get tmux
+$ codex mcp list;          codex mcp get tmux
+$ gemini mcp list
+$ cursor-agent mcp list-tools tmux      # NOT `mcp list` — see trap below
+```
+
+## Headless one-shot (Layer 1)
+
+```console
+$ codex -a never exec --sandbox read-only --json -C /repo \
+    'Call the tmux MCP: list sessions and report the count.'
+
+$ gemini --skip-trust --allowed-mcp-server-names tmux --approval-mode yolo \
+    --output-format json -p 'Call the tmux MCP: list sessions.'
+
+$ cursor-agent --print --output-format stream-json --trust --approve-mcps \
+    --sandbox enabled --mode ask --workspace /repo \
+    'Call the tmux MCP: list sessions.'
+```
+
+Claude headless: `claude -p '<prompt>'` (add MCP scope/permission flags as your
+setup requires). Grok and agy follow the interactive (Layer 2) path unless a
+current `--help` shows a print/exec mode.
+
+## Per-CLI traps
+
+- **cursor-agent `mcp list` under-reports.** It can say `not loaded (needs
+  approval)` while `cursor-agent mcp list-tools tmux` returns the full list and
+  Composer calls the tools fine. `list-tools` + one real call is the
+  authoritative proof, not the status string.
+- **Codex approval-flag placement.** Use the top-level form `codex -a never
+  exec ...`; passing the approval policy *after* `exec` fails.
+- **Claude account state can block headless runs** (`Credit balance is too
+  low`). That's a client/account limit, not a server bug — fall back to Layer 2
+  or Layer 0.
+- **Claude worktree scope shadowing.** Claude maps a linked git worktree to the
+  main worktree path for per-project MCP, so a per-project entry can out-rank a
+  `--scope user` swap. Know which layer you're actually hitting with `claude mcp
+  get`.
+
+## Native `mcp add` (per CLI) — for injecting env like LIBTMUX_SOCKET
+
+mcp_swap preserves existing env but does not add new keys, so to sandbox the
+socket use each CLI's own add command (syntax varies; the `-e` / `--env`
+placement is the usual footgun):
+
+```console
+$ claude mcp add tmux -s user -e LIBTMUX_SOCKET=mcp-target -- uv --directory /repo run libtmux-mcp
+$ codex  mcp add tmux --env LIBTMUX_SOCKET=mcp-target       -- uv --directory /repo run libtmux-mcp
+$ gemini mcp add tmux -s user -e LIBTMUX_SOCKET=mcp-target  uv -- --directory /repo run libtmux-mcp
+$ grok   mcp add tmux -e LIBTMUX_SOCKET=mcp-target          -- uv --directory /repo run libtmux-mcp
+```
+
+Cursor and agy have no `mcp add` — edit their JSON config directly
+(`~/.cursor/mcp.json`, `~/.gemini/config/mcp_config.json`) with the same
+`command` / `args` / `env` shape, then approve in-app.
+
+## mcp_swap traps (this repo)
+
+- **Pass `--server tmux`.** The script derives the slug `libtmux` from the
+  package name, but the effective registered key on this machine is `tmux`.
+  Without the flag you swap a `libtmux` entry nobody uses — `status` with no flag
+  reports `no entry for 'libtmux'` across all six CLIs.
+- **`--entry` when the first `[project.scripts]` key isn't the MCP entry.** Here
+  the only script is `libtmux-mcp`, so the default is fine; other repos (e.g.
+  agentgrep needed `--entry agentgrep-mcp`) do not get that for free.
+- **`use-local` mutates real user configs.** Dry-run first; `revert` unwinds from
+  timestamped backups in LIFO order when swaps stack.
+
+## Direct-smoke sanity values (Layer 0, libtmux-mcp)
+
+A healthy default-tier smoke against an isolated socket has looked like: `~52`
+tools visible, `list_sessions` works, `call_readonly_tools_batch` works,
+`send_keys_batch` preserves op order, and an oversized batch is rejected with
+`operations must contain at most 1000 tool calls`. Exact tool count shifts as the
+surface evolves — treat these as a shape check, not a fixed assertion.

--- a/.claude/skills/testing-mcp-with-cli-agents
+++ b/.claude/skills/testing-mcp-with-cli-agents
@@ -1,0 +1,1 @@
+../../.agents/skills/testing-mcp-with-cli-agents

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,19 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Development
+
+**`mcp_swap.py doctor` and `use-local --env`**
+
+The dev config-swap helper gains a read-only `doctor` subcommand that reports
+the effective MCP-swap environment — which server name each CLI points at (and a
+mismatch when the repo is registered under a name other than the derived
+default), un-reverted swaps and orphaned backups accumulating on disk, a state
+entry whose backup has gone missing, and auth-overriding env vars such as
+`OPENAI_API_KEY`. `use-local` also takes a repeatable `--env KEY=VALUE` to write
+env (e.g. an isolated `LIBTMUX_SOCKET`) into the server entry without a manual
+post-edit.
+
 ## libtmux-mcp 0.1.0a18 (2026-07-12)
 
 libtmux-mcp 0.1.0a18 raises the libtmux floor to 0.62.0 and tightens how the server handles lookups that cannot succeed. A readonly call carrying a stale or ambiguous id now fails on the first attempt instead of paying a second tmux round-trip and a backoff window to fail identically, and an ambiguous target — a window shared between sessions, matched by name or index — now comes back with a recovery hint that says to target it by id instead of an unexplained error. The floor bump is what makes both fixes possible: libtmux 0.62.0 folds its query errors into the {exc}`libtmux.exc.LibTmuxException` hierarchy the server keys on.

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -838,6 +838,11 @@ def cmd_use_local(args: argparse.Namespace) -> int:
     server = args.server or server
     entry = args.entry or default_entry
     spec = build_local_spec(repo, entry)
+    extra_env = dict(args.env or [])
+
+    hint = _naming_hint(repo, server)
+    if hint:
+        print(hint, file=sys.stderr)
 
     targets = args.cli or present_clis()
     if not targets:
@@ -867,6 +872,7 @@ def cmd_use_local(args: argparse.Namespace) -> int:
                 current
                 and current.is_local_uv_directory()
                 and current.local_repo_path() == repo
+                and all(current.env.get(k) == v for k, v in extra_env.items())
             ):
                 print(f"[{label}] already local (this repo) — no change")
                 continue
@@ -875,8 +881,12 @@ def cmd_use_local(args: argparse.Namespace) -> int:
             # client-side settings (LIBTMUX_SAFETY, LIBTMUX_SOCKET, custom dev
             # knobs). Symmetric with ``_spec_from_entry`` which round-trips env on
             # the read side.
+            base_env = dict(current.env) if current else {}
+            base_env.update(extra_env)
             cli_spec = (
-                dataclasses.replace(spec, env={**current.env}) if current else spec
+                dataclasses.replace(spec, env=base_env)
+                if (current or extra_env)
+                else spec
             )
             action = set_server(cli, config, server, cli_spec, repo, scope=scope)
             new_bytes = dump_config_bytes(info, config)
@@ -1013,6 +1023,204 @@ def cmd_revert(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# doctor — read-only diagnostics
+# ---------------------------------------------------------------------------
+
+#: Env vars that, when set, override a CLI's stored subscription/login auth
+#: with an API key — a frequent cause of "why is it billing / refusing?"
+#: surprises when driving the CLI against a local server. Doctor only reports
+#: presence; it never reads the value.
+AUTH_ENV_VARS: dict[str, CLIName] = {
+    "ANTHROPIC_API_KEY": "claude",
+    "OPENAI_API_KEY": "codex",
+    "GEMINI_API_KEY": "gemini",
+    "GOOGLE_API_KEY": "gemini",
+    "XAI_API_KEY": "grok",
+    "GROK_API_KEY": "grok",
+}
+
+
+def _env_pair(raw: str) -> tuple[str, str]:
+    """Parse a ``KEY=VALUE`` ``--env`` argument, or raise for argparse."""
+    key, sep, value = raw.partition("=")
+    if not sep or not key:
+        msg = f"--env expects KEY=VALUE, got {raw!r}"
+        raise argparse.ArgumentTypeError(msg)
+    return key, value
+
+
+def _config_present_clis() -> list[CLIName]:
+    """CLIs whose config file exists — enough to *read* entries (no binary needed).
+
+    Distinct from :func:`present_clis`, which also requires the binary on
+    ``PATH``. Doctor and the naming hint only inspect config files, so a CLI
+    whose binary is absent but whose config is present still has readable
+    entries worth surfacing.
+    """
+    return [cli for cli in ALL_CLIS if CLIS[cli].config_path.exists()]
+
+
+def _all_server_specs(
+    cli: CLIName, config: t.Any, repo: pathlib.Path
+) -> dict[str, McpServerSpec]:
+    """Enumerate every MCP server entry visible in a CLI's config.
+
+    Spans the scopes a CLI actually keys servers under: Claude's top-level
+    user ``mcpServers`` plus this repo's per-project node, and the single
+    ``mcpServers`` / ``mcp_servers`` table for the others. Used to detect the
+    server-name footgun — the repo registered under a name other than the
+    derived default — which a same-name-only lookup misses.
+    """
+    out: dict[str, McpServerSpec] = {}
+
+    def _add(raw: t.Any) -> None:
+        if not isinstance(raw, dict):
+            return
+        for name, entry in raw.items():
+            if not isinstance(entry, dict):
+                continue
+            out[str(name)] = _spec_from_entry(entry, fmt=CLIS[cli].fmt)
+
+    if cli == "claude":
+        _add(_claude_user_servers(config, create=False))
+        node = _claude_project_node(config, repo, create=False)
+        if node:
+            _add(node.get("mcpServers"))
+    elif cli in ("cursor", "gemini", "agy"):
+        _add(config.get("mcpServers"))
+    else:  # codex, grok
+        _add(config.get("mcp_servers"))
+    return out
+
+
+def _repo_pointing_names(cli: CLIName, config: t.Any, repo: pathlib.Path) -> list[str]:
+    """Server names in this CLI's config whose local checkout is ``repo``."""
+    return sorted(
+        name
+        for name, spec in _all_server_specs(cli, config, repo).items()
+        if spec.is_local_uv_directory() and spec.local_repo_path() == repo
+    )
+
+
+def _naming_hint(repo: pathlib.Path, server: str) -> str | None:
+    """Suggest ``--server <name>`` when the repo is registered under another name.
+
+    The derived default (package name minus ``-mcp``) often doesn't match the
+    slug the CLIs were actually registered under (e.g. ``tmux`` vs the derived
+    ``libtmux``), so a bare run silently operates on a non-existent entry.
+    Returns a one-line hint naming the real slug, or ``None`` when the derived
+    name is already the registered one (or nothing points here).
+    """
+    names: set[str] = set()
+    server_points = False
+    for cli in _config_present_clis():
+        try:
+            config = load_config(CLIS[cli])
+            pointing = _repo_pointing_names(cli, config, repo)
+        except (RuntimeError, ValueError, OSError):
+            continue
+        for name in pointing:
+            if name == server:
+                server_points = True
+            else:
+                names.add(name)
+    if server_points or not names:
+        return None
+    pick = sorted(names)[0]
+    return (
+        f"note: nothing is registered under server {server!r}, but this repo is "
+        f"registered as {sorted(names)} — pass --server {pick} to target it"
+    )
+
+
+def _orphaned_backups(config_path: pathlib.Path) -> list[pathlib.Path]:
+    """All ``mcp-swap`` backups sitting next to ``config_path`` (any timestamp)."""
+    pattern = config_path.name + BACKUP_SUFFIX_PREFIX + "*"
+    return sorted(config_path.parent.glob(pattern))
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    """Report the effective MCP-swap environment without changing anything.
+
+    Read-only. Surfaces the footguns that swap/status don't: the repo
+    registered under an unexpected server name, un-reverted swaps and orphaned
+    backups accumulating on disk, a state entry whose backup has gone missing
+    (so revert would fail), and auth-overriding env vars. It deliberately does
+    NOT model each CLI's config-merge behaviour — that is CLI-version-specific
+    and lives in documentation, not here.
+    """
+    repo = pathlib.Path(args.repo).resolve()
+    server = args.server or resolve_repo_meta(repo)[0]
+    print("mcp-swap doctor")
+    print(f"  repo:   {repo}")
+    print(f"  server: {server}  (derived default; override with --server)")
+
+    print("  entries by CLI:")
+    all_repo_names: set[str] = set()
+    for cli in _config_present_clis():
+        try:
+            config = load_config(CLIS[cli])
+            specs = _all_server_specs(cli, config, repo)
+            pointing = _repo_pointing_names(cli, config, repo)
+        except (RuntimeError, ValueError, OSError) as exc:
+            print(f"    [{cli}] config unreadable: {exc}")
+            continue
+        spec = specs.get(server)
+        if spec is not None:
+            print(f"    [{cli}] {server} = {_describe_spec(spec, repo)}")
+        all_repo_names.update(pointing)
+        for name in pointing:
+            if name != server:
+                print(f"    [{cli}] {name} = local: this repo  (other name)")
+    if not all_repo_names:
+        print("    (no CLI currently points at this repo)")
+
+    if all_repo_names and server not in all_repo_names:
+        pick = sorted(all_repo_names)[0]
+        print(
+            f"  ! server name mismatch: this repo is registered as "
+            f"{sorted(all_repo_names)}, not {server!r} — use --server {pick}"
+        )
+
+    state = load_state()
+    if state:
+        print("  outstanding swaps (un-reverted):")
+        for (cli, scope), entry in sorted(state.items(), key=lambda kv: kv[1].seq_no):
+            flag = (
+                ""
+                if pathlib.Path(entry.backup_path).exists()
+                else "  ! BACKUP MISSING — revert would fail for this entry"
+            )
+            print(f"    {cli}:{scope}  swapped_at={entry.swapped_at}{flag}")
+
+    referenced = {e.backup_path for e in state.values()}
+    orphans = [
+        b
+        for info in CLIS.values()
+        for b in _orphaned_backups(info.config_path)
+        if str(b) not in referenced
+    ]
+    if orphans:
+        total = sum(b.stat().st_size for b in orphans if b.exists())
+        print(
+            f"  orphaned backups: {len(orphans)} file(s), {total} bytes not tracked "
+            "by state — safe to delete"
+        )
+
+    auth_hits = [
+        (var, cli) for var, cli in AUTH_ENV_VARS.items() if os.environ.get(var)
+    ]
+    if auth_hits:
+        print("  auth-overriding env vars set:")
+        for var, cli in auth_hits:
+            print(
+                f"    ! {var} overrides {cli}'s stored login — prefix with "
+                f"`env -u {var}` to use the subscription/OAuth auth instead"
+            )
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # argparse glue
 # ---------------------------------------------------------------------------
 
@@ -1056,6 +1264,17 @@ def build_parser() -> argparse.ArgumentParser:
     pu.add_argument(
         "--entry", help="uv run entry command (default: [project.scripts] first key)"
     )
+    pu.add_argument(
+        "--env",
+        action="append",
+        type=_env_pair,
+        metavar="KEY=VALUE",
+        help=(
+            "Extra env var to write into the server entry (repeatable). "
+            "Layered on top of any preserved existing env; explicit --env wins. "
+            "Use to inject e.g. LIBTMUX_SOCKET without a manual post-edit."
+        ),
+    )
     pu.add_argument("--cli", action="append", choices=ALL_CLIS)
     pu.add_argument(
         "--scope",
@@ -1084,6 +1303,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     pr.add_argument("--dry-run", action="store_true")
     pr.set_defaults(func=cmd_revert)
+
+    pd = sub.add_parser(
+        "doctor", help="report the effective MCP-swap environment (read-only)"
+    )
+    pd.add_argument("--repo", default=".", help="repo root (default: .)")
+    pd.add_argument(
+        "--server", help="MCP server name (default: derived from pyproject.toml)"
+    )
+    pd.set_defaults(func=cmd_doctor)
 
     return p
 

--- a/tests/test_mcp_swap.py
+++ b/tests/test_mcp_swap.py
@@ -1461,3 +1461,270 @@ def test_status_scope_user_with_only_project_entry_shows_no_entry(
     out = capsys.readouterr().out
     assert "[claude:user] no entry for" in out
     assert "[claude:project]" not in out
+
+
+# ---------------------------------------------------------------------------
+# use-local --env injection
+# ---------------------------------------------------------------------------
+
+
+def _local_entry(repo: pathlib.Path) -> dict[str, t.Any]:
+    """Return a local ``uv --directory <repo> run`` JSON entry (use-local shape)."""
+    return {
+        "command": "uv",
+        "args": ["--directory", str(repo.resolve()), "run", "libtmux-mcp"],
+    }
+
+
+def test_use_local_env_flag_injects_into_entry(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """``--env KEY=VALUE`` lands in the written server entry's ``env``.
+
+    The isolation workflow needs to point the server at a scratch socket
+    without a manual post-edit; ``--env`` writes that env at swap time.
+    """
+    info = mcp_swap.CLIS["cursor"]
+    _write_json(info.config_path, {"mcpServers": {}})
+
+    args = mcp_swap.build_parser().parse_args(
+        [
+            "use-local",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "cursor",
+            "--env",
+            "LIBTMUX_SOCKET=mcp-target",
+        ]
+    )
+    assert mcp_swap.cmd_use_local(args) == 0
+
+    entry = json.loads(info.config_path.read_text())["mcpServers"]["libtmux"]
+    assert entry["env"] == {"LIBTMUX_SOCKET": "mcp-target"}
+
+
+def test_use_local_env_flag_wins_over_preserved_env(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """Explicit ``--env`` overrides a preserved key; other preserved keys survive."""
+    info = mcp_swap.CLIS["cursor"]
+    _write_json(
+        info.config_path,
+        {
+            "mcpServers": {
+                "libtmux": {
+                    "command": "uvx",
+                    "args": ["libtmux-mcp==0.1.0a2"],
+                    "env": {"LIBTMUX_SAFETY": "readonly", "KEEP": "me"},
+                }
+            }
+        },
+    )
+
+    args = mcp_swap.build_parser().parse_args(
+        [
+            "use-local",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "cursor",
+            "--env",
+            "LIBTMUX_SAFETY=destructive",
+        ]
+    )
+    assert mcp_swap.cmd_use_local(args) == 0
+
+    entry = json.loads(info.config_path.read_text())["mcpServers"]["libtmux"]
+    assert entry["env"] == {"LIBTMUX_SAFETY": "destructive", "KEEP": "me"}
+
+
+def test_env_pair_rejects_malformed() -> None:
+    """``--env`` without ``=`` is an argparse error, not a silent skip."""
+    with pytest.raises(SystemExit):
+        mcp_swap.build_parser().parse_args(["use-local", "--env", "NOEQUALS"])
+
+
+def test_use_local_env_written_on_already_local_entry(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """``--env`` still writes when the entry already points at this repo.
+
+    Regression: the already-local short-circuit ``continue``d before the env
+    merge, so ``--env`` (e.g. an isolated ``LIBTMUX_SOCKET``) was silently
+    dropped whenever the config already pointed local — the common case. The
+    guard now only short-circuits when the requested env is already satisfied.
+    """
+    info = mcp_swap.CLIS["cursor"]
+    _write_json(info.config_path, {"mcpServers": {"libtmux": _local_entry(fake_repo)}})
+
+    args = mcp_swap.build_parser().parse_args(
+        [
+            "use-local",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "cursor",
+            "--env",
+            "LIBTMUX_SOCKET=mcp-target",
+        ]
+    )
+    assert mcp_swap.cmd_use_local(args) == 0
+
+    entry = json.loads(info.config_path.read_text())["mcpServers"]["libtmux"]
+    assert entry.get("env") == {"LIBTMUX_SOCKET": "mcp-target"}
+
+
+def test_use_local_already_local_still_noop_when_env_matches(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """The short-circuit still fires when the requested env is already present."""
+    info = mcp_swap.CLIS["cursor"]
+    spec = _local_entry(fake_repo)
+    spec["env"] = {"LIBTMUX_SOCKET": "mcp-target"}
+    _write_json(info.config_path, {"mcpServers": {"libtmux": spec}})
+    before = info.config_path.read_bytes()
+
+    args = mcp_swap.build_parser().parse_args(
+        [
+            "use-local",
+            "--repo",
+            str(fake_repo),
+            "--cli",
+            "cursor",
+            "--env",
+            "LIBTMUX_SOCKET=mcp-target",
+        ]
+    )
+    assert mcp_swap.cmd_use_local(args) == 0
+    assert info.config_path.read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# naming hint
+# ---------------------------------------------------------------------------
+
+
+def test_naming_hint_points_at_registered_alias(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """Hint names the real slug when the repo uses a non-default server name.
+
+    A bare run would otherwise no-op on a missing entry, so the hint points
+    at the name the CLIs were actually registered under.
+    """
+    _write_json(
+        mcp_swap.CLIS["cursor"].config_path,
+        {"mcpServers": {"tmux": _local_entry(fake_repo)}},
+    )
+    hint = mcp_swap._naming_hint(fake_repo.resolve(), "libtmux")
+    assert hint is not None
+    assert "--server tmux" in hint
+
+
+def test_naming_hint_none_when_derived_name_matches(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """No hint when the repo is already registered under the derived name."""
+    _write_json(
+        mcp_swap.CLIS["cursor"].config_path,
+        {"mcpServers": {"libtmux": _local_entry(fake_repo)}},
+    )
+    assert mcp_swap._naming_hint(fake_repo.resolve(), "libtmux") is None
+
+
+def test_naming_hint_none_when_repo_also_registered_under_derived(
+    fake_home: pathlib.Path, fake_repo: pathlib.Path
+) -> None:
+    """No hint when the derived name points here, even if another name does too.
+
+    Regression: the hint used to fire on the other name and falsely claim
+    'nothing is registered under <derived>' when the derived name in fact
+    points at the repo.
+    """
+    _write_json(
+        mcp_swap.CLIS["cursor"].config_path,
+        {
+            "mcpServers": {
+                "libtmux": _local_entry(fake_repo),
+                "tmux": _local_entry(fake_repo),
+            }
+        },
+    )
+    assert mcp_swap._naming_hint(fake_repo.resolve(), "libtmux") is None
+
+
+# ---------------------------------------------------------------------------
+# doctor
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_reports_name_mismatch_and_auth_env(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Doctor surfaces the server-name mismatch and auth-overriding env vars."""
+    _write_json(
+        mcp_swap.CLIS["cursor"].config_path,
+        {"mcpServers": {"tmux": _local_entry(fake_repo)}},
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    args = mcp_swap.build_parser().parse_args(["doctor", "--repo", str(fake_repo)])
+    assert mcp_swap.cmd_doctor(args) == 0
+    out = capsys.readouterr().out
+    assert "server name mismatch" in out
+    assert "--server tmux" in out
+    assert "OPENAI_API_KEY" in out and "codex" in out
+
+
+def test_doctor_flags_missing_backup_and_orphans(
+    fake_home: pathlib.Path,
+    fake_repo: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Doctor flags a state entry whose backup vanished, and untracked backups."""
+    info = mcp_swap.CLIS["cursor"]
+    _write_json(info.config_path, {"mcpServers": {"libtmux": _local_entry(fake_repo)}})
+    # A recorded swap whose backup file does not exist -> revert would fail.
+    mcp_swap.save_state(
+        {
+            ("cursor", "user"): mcp_swap.SwapEntry(
+                config_path=str(info.config_path),
+                backup_path=str(info.config_path) + ".bak.mcp-swap-20200101000000",
+                server="libtmux",
+                action="replaced",
+                swapped_at="20200101000000",
+                seq_no=0,
+            )
+        }
+    )
+    # An orphaned backup on disk not referenced by state.
+    orphan = info.config_path.parent / (
+        info.config_path.name + ".bak.mcp-swap-20190101000000"
+    )
+    orphan.write_text("stale")
+
+    args = mcp_swap.build_parser().parse_args(["doctor", "--repo", str(fake_repo)])
+    assert mcp_swap.cmd_doctor(args) == 0
+    out = capsys.readouterr().out
+    assert "BACKUP MISSING" in out
+    assert "orphaned backups" in out
+
+
+def test_orphaned_backups_matches_swap_pattern(
+    fake_home: pathlib.Path,
+) -> None:
+    """``_orphaned_backups`` finds swap backups and ignores the live config."""
+    info = mcp_swap.CLIS["cursor"]
+    info.config_path.parent.mkdir(parents=True, exist_ok=True)
+    info.config_path.write_text("{}\n")
+    b1 = info.config_path.parent / (
+        info.config_path.name + ".bak.mcp-swap-20260101000000"
+    )
+    b1.write_text("x")
+    found = mcp_swap._orphaned_backups(info.config_path)
+    assert b1 in found
+    assert info.config_path not in found


### PR DESCRIPTION
## Summary

- **Add** a `testing-mcp-with-cli-agents` skill — a verified method for driving all six installed agent CLIs (Claude, Codex, Cursor, Gemini, Grok, agy) against the server on isolated tmux sockets and asserting ground truth, instead of trusting unit tests alone.
- **Add** a read-only `mcp_swap.py doctor` subcommand that reports the effective swap environment: which server name each CLI points at (and a mismatch when the repo is registered under a name other than the derived default), un-reverted swaps and orphaned backups on disk, a state entry whose backup has gone missing (so `revert` would fail), and auth-overriding env vars such as `OPENAI_API_KEY`.
- **Add** `use-local --env KEY=VALUE` (repeatable) to write env — e.g. an isolated `LIBTMUX_SOCKET` — into the server entry at swap time, layered over preserved env.
- **Add** a naming hint on `use-local` when the repo is registered under a server name other than the derived default, so a bare run doesn't silently no-op on a missing entry.

## Changes by area

### Dev tooling — `scripts/mcp_swap.py`

- **`doctor`**: cross-CLI entry inventory, server-name mismatch hint, outstanding-swap and orphaned-backup health, missing-backup detection, and auth-env override warnings. Read-only; deliberately does not model each CLI's config-merge behaviour (that is version-specific and lives in the skill docs).
- **`use-local --env`**: repeatable `KEY=VALUE`, merged over any preserved env, explicit wins.
- **naming hint**: surfaced on `use-local` and in `doctor` via a reusable scan for repo-pointing entries registered under another name.

### Skill — `.agents/skills/testing-mcp-with-cli-agents/`

- `SKILL.md`: the three-socket isolation model, three fidelity layers (direct smoke, headless one-shot, interactive send-keys), the cancellation/orphan test, and trunk-vs-branch comparison.
- `references/cli-matrix.md`: per-CLI isolation lever, cheapest discovery proof, headless invocation, and approval-bypass flag — verified across all six CLIs.
- Linked into `.claude/skills/` via a committed relative symlink; the source lives in the tool-neutral `.agents/` tree (`.claude/` is git-ignored).

## Design decisions

- **`doctor` reports observable state, not CLI internals**: it inventories config entries, swap state, backups, and env vars — all stable and observable — but does not encode version-specific config-merge behaviour, which would rot. That knowledge lives in the skill's cli-matrix with a dated caveat.
- **Server-agnostic implementation**: the new helpers derive the server slug from `pyproject.toml` and hardcode no name, so the same logic ports to sibling repos that vendor `mcp_swap.py`.
- **Zero-mutation isolation preferred for tests**: the skill steers testers toward each CLI's throwaway config-home / project-config lever over `mcp_swap use-local`, since a swap mutates real configs; `doctor` and `--env` make the swap path safer when it is used.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .`
- [x] `uv run mypy src tests`
- [x] `uv run pytest tests/test_mcp_swap.py` — env injection, naming hint, and `doctor` (mismatch, missing-backup, orphaned-backup) coverage
- [x] `uv run pytest` — full suite green
- [x] `just build-docs` — CHANGES renders
- [x] `uv run scripts/mcp_swap.py doctor --server tmux` — read-only smoke against the real environment
