### PR TITLE
mcp(docs[_utils]): Document CallerIdentity fields

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,14 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Documentation
+
+#### Caller identity fields are described (#105)
+
+The dataclass identifying an MCP caller now says what each field holds. They
+previously reached the rendered API reference as "Alias for field number 0"
+or as a bare name carrying only its type.
+
 ### Development
 
 #### CI actions updated to current majors

--- a/src/libtmux_mcp/_utils.py
+++ b/src/libtmux_mcp/_utils.py
@@ -104,6 +104,26 @@ class CallerIdentity:
     Used to scope self-protection checks to the caller's own tmux server —
     a pane ID like ``%1`` is only unique within a single server, so
     comparisons must also verify the socket path matches.
+
+    Attributes
+    ----------
+    socket_path : str | None
+        Filesystem path of the tmux socket the caller is attached to, from
+        the first ``TMUX`` field. ``None`` when ``TMUX`` is unset or its
+        first field is empty — the socket comparisons in
+        :func:`_caller_is_on_server` and
+        :func:`_caller_is_strictly_on_server` then cannot prove which
+        server the caller belongs to.
+    server_pid : int | None
+        PID of the tmux server process, from the second ``TMUX`` field.
+        ``None`` when that field is absent or not an integer.
+    session_id : str | None
+        Session the caller's pane belongs to (e.g. ``$7``), from the third
+        ``TMUX`` field. ``None`` when that field is absent or empty.
+    pane_id : str | None
+        Pane the MCP server process runs in (e.g. ``%3``), read from
+        ``TMUX_PANE``. ``None`` when the variable is unset, meaning no
+        pane can be identified as the caller's own.
     """
 
     socket_path: str | None


### PR DESCRIPTION
`CallerIdentity` carried a class docstring but no per-field descriptions, so autodoc rendered its fields bare in the API reference (a NamedTuple in the same position renders as "Alias for field number 0"), leaving readers to guess which `$TMUX` / `$TMUX_PANE` component each field holds and what its `None` sentinel means for the caller-on-server checks. This adds a NumPy `Attributes` section naming the source environment variable field and the meaning of an unset value for each. Docstrings only — no code, signature, or field-order changes.

Gates run and passing: `just ruff-format`, `just ruff`, `uv run mypy .`, `just test`, `just build-docs`.

The docs build now emits duplicate-object warnings for the four documented fields (`duplicate object description of libtmux_mcp._utils.CallerIdentity.<field>, other instance in reference/api/utils`). The NumPy preprocessor emits an `.. attribute::` for each entry while autodoc also renders the field, so both register the same object. The build still succeeds. Left unsuppressed here deliberately — the fix belongs in gp-sphinx and is being handled there rather than by adding a `suppress_warnings` entry to `docs/conf.py`.

Closes #104
