### PR TITLE
mcp(chore[pytest]): Stop hiding our own deprecation warnings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,27 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Development
+
+**The test suite can see deprecation warnings again**
+
+`filterwarnings` silenced `DeprecationWarning` for `libtmux.*`,
+`libtmux_mcp.*`, and `tests`. A deprecation is attributed to the frame the
+raising library points `stacklevel` at — the caller — so those three patterns
+matched exactly the warnings saying this codebase must change, while unrelated
+third-party noise still surfaced. `FastMCPDeprecationWarning` subclasses
+`DeprecationWarning`, so FastMCP's own deprecations were caught by the same
+filters.
+
+The three blanket entries are gone; the message-scoped docutils filter stays.
+The suite is quiet without them apart from the one warning they were hiding,
+now fixed: `asyncio.iscoroutinefunction` is deprecated and slated for removal
+in Python 3.16, replaced with `inspect.iscoroutinefunction`.
+
+`DeprecationWarning` is deliberately not escalated to an error. This project
+pins two fast-moving pre-2.0 dependencies, and an upstream patch release should
+not be able to turn CI red on its own schedule.
+
 ## libtmux-mcp 0.1.0a19 (2026-07-25)
 
 libtmux-mcp 0.1.0a19 makes {tooliconl}`wait-for-text` see the output it was asked to watch for, and puts a ceiling under every wait. The tool anchored one row below the cursor's position at entry, which on a quiescent pane is exactly where the next line lands, so the case it exists for — output you did not author, a daemon printing a single `ready` line — could not match at all. Waits are now bounded by a server ceiling, cancellable without orphaning their tmux child, and report an `outcome` that distinguishes a command that never ran from output that did not match from a pager owning the pane. The wait API changes shape in the process: `pattern` becomes `patterns`, `stop` markers end a wait early, and `wait_for_content_change` is removed in favour of `wait_for_text(patterns=null)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,9 +255,8 @@ testpaths = [
   "src/libtmux_mcp",
   "tests",
 ]
+# Filter by message, not by module: a module pattern matches the frame
+# `stacklevel` points at, which for a deprecation is our own caller.
 filterwarnings = [
   "ignore:The frontend.Option(Parser)? class.*:DeprecationWarning::",
-  "ignore::DeprecationWarning:libtmux.*:",
-  "ignore::DeprecationWarning:libtmux_mcp.*:",
-  "ignore::DeprecationWarning:tests:",
 ]

--- a/tests/test_wait_for_tools.py
+++ b/tests/test_wait_for_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import os
 import pathlib
 import signal
@@ -54,8 +55,8 @@ def test_channel_tools_are_coroutines() -> None:
     assertion pins the async surface so a silent revert doesn't sneak
     through.
     """
-    assert asyncio.iscoroutinefunction(wait_for_channel)
-    assert asyncio.iscoroutinefunction(signal_channel)
+    assert inspect.iscoroutinefunction(wait_for_channel)
+    assert inspect.iscoroutinefunction(signal_channel)
 
 
 @pytest.mark.usefixtures("mcp_session")


### PR DESCRIPTION
Closes #111.

`filterwarnings` silenced `DeprecationWarning` for `libtmux.*`, `libtmux_mcp.*`, and `tests`. Those look like they filter dependency noise. They do the opposite.

A deprecation is attributed to the frame the raising library points `stacklevel` at, which by convention is the *caller* — so the warning that says "this line uses a deprecated API" is attributed to `libtmux_mcp.something` or to the test body that exercised it. The three filters matched precisely those, while a warning from an unrelated package sailed through. `FastMCPDeprecationWarning` subclasses `DeprecationWarning`, so FastMCP's own deprecations were caught too.

## Evidence

A/B probe under the repo's real config — two tests, one run, one warning emitted from each namespace:

| Warning attributed to | Result |
| --- | --- |
| `libtmux_mcp.server` | suppressed, absent from the warnings summary |
| `some_other_package.thing` | surfaces normally |

And the MRO, since it's what makes the category filters reach FastMCP:

```
FastMCPDeprecationWarning.__mro__ -> (FastMCPDeprecationWarning, DeprecationWarning, Warning, ...)
```

## What was hidden

Exactly one thing, and it is real. Removing the filters surfaced `asyncio.iscoroutinefunction` at `tests/test_wait_for_tools.py:57-58` — *"deprecated and slated for removal in Python 3.16; use `inspect.iscoroutinefunction()` instead"*. Fixed here.

Nothing else warns. The suppression bought no quiet; it cost one signal, and that signal was a scheduled standard-library removal.

## Why now

[SEP-2596](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2596) obliges Tier 1 SDKs to emit a runtime `DeprecationWarning` when a deprecated feature is exercised, once that feature enters the Deprecated state. Three things land imminently: spec revision `2026-07-28` (which deprecates Roots, Sampling, and Logging via [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577)), `mcp` 2.0.0 targeted for the same date, and `fastmcp` v4 already in alpha against the `<4.0.0` ceiling here.

There is real exposure waiting behind that: 13 `.inputSchema` reads across the history tests, `mcp.types` imports in `middleware.py` (the submodule becomes a standalone package in 2.x), and `_client_label()` reading client identity off the `initialize` handshake that `2026-07-28` removes. None of it can break today — `fastmcp` 3.4.4 pins `mcp<2.0`, so 2.x cannot resolve into this environment — but warnings are how that transition is meant to announce itself, and the suite was configured not to listen.

## What this does not do

It does not escalate `DeprecationWarning` to an error. This project pins two fast-moving pre-2.0 dependencies; making warnings fatal hands upstream the ability to turn CI red on its own release schedule, with no local change. Visible-but-not-fatal restores the signal without that coupling. Worth revisiting once `mcp` 2.x and `fastmcp` v4 have settled.

The message-scoped docutils filter is untouched — that one is correctly shaped, filtering a specific known message rather than a category across a module.

## Verification

`ruff check`, `ruff format --check`, `mypy` (65 files), `pytest --reruns 0` (**801 passed, 0 warnings**), `just build-docs` clean.

Independent of #110, which is also open — that one migrates `wait_for_text` off the deprecated MCP Logging capability. No overlapping files.
