### PR TITLE
Bump ruff floor to 0.16.0 and adopt its default rule set

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,21 @@ blocks inside Markdown, so `uv run ruff format .` reaches the README and the
 `docs/` tree. Neither the lint nor the format change rewrites anything here.
 (#113)
 
+**ruff's curated default rule set is now enabled**
+
+`[tool.ruff.lint]` layers this project's linters on with `extend-select` instead
+of `select`. An explicit `select` replaces ruff's default set rather than adding
+to it, so the project had been silently opting out of every rule it did not name
+itself; enabled rules go from 351 to 565. The findings that surfaced are fixed —
+`re.DOTALL` spelled out in place of `re.S`, `str.removesuffix` and `min()` in
+`scripts/mcp_swap.py`, the server instruction blob built as an f-string, and the
+wrapped marker fixtures parenthesized so a dropped comma can no longer pass for
+a deliberate join. Two rules are scoped ignores with their reasons recorded in
+`pyproject.toml`: `exec` in `docs/conf.py`, which is how Sphinx reads version
+metadata, and the `except Exception` boundaries in the error middleware, the
+batch runners, the best-effort tmux probes, and `mcp_swap`'s config rollback.
+(#113)
+
 ## libtmux-mcp 0.1.0a19 (2026-07-25)
 
 libtmux-mcp 0.1.0a19 makes {tooliconl}`wait-for-text` see the output it was asked to watch for, and puts a ceiling under every wait. The tool anchored one row below the cursor's position at entry, which on a quiescent pane is exactly where the next line lands, so the case it exists for — output you did not author, a daemon printing a single `ready` line — could not match at all. Waits are now bounded by a server ceiling, cancellable without orphaning their tmux child, and report an `outcome` that distinguishes a command that never ran from output that did not match from a pager owning the pane. The wait API changes shape in the process: `pattern` becomes `patterns`, `stop` markers end a wait early, and `wait_for_content_change` is removed in favour of `wait_for_text(patterns=null)`.

--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,15 @@ Workflow actions moved to their current major releases: `actions/checkout` v7,
 and `dorny/paths-filter` v4. Workflow behavior is unchanged, though setup-uv no
 longer prunes the uv cache, so the first run after this repopulates it.
 
+**Minimum `ruff>=0.16.0`** (was unpinned)
+
+The `dev` and `lint` dependency groups now require ruff 0.16.0 or newer, so
+contributors and CI see the same diagnostics rather than whichever ruff each
+machine resolved. From this release on, `ruff format` also formats Python code
+blocks inside Markdown, so `uv run ruff format .` reaches the README and the
+`docs/` tree. Neither the lint nor the format change rewrites anything here.
+(#113)
+
 ## libtmux-mcp 0.1.0a19 (2026-07-25)
 
 libtmux-mcp 0.1.0a19 makes {tooliconl}`wait-for-text` see the output it was asked to watch for, and puts a ceiling under every wait. The tool anchored one row below the cursor's position at entry, which on a quiescent pane is exactly where the next line lands, so the case it exists for — output you did not author, a daemon printing a single `ready` line — could not match at all. Waits are now bounded by a server ceiling, cancellable without orphaning their tmux child, and report an `outcome` that distinguishes a command that never ran from output that did not match from a pager owning the pane. The wait API changes shape in the process: `pattern` becomes `patterns`, `stop` markers end a wait early, and `wait_for_content_change` is removed in favour of `wait_for_text(patterns=null)`.

--- a/CHANGES
+++ b/CHANGES
@@ -41,7 +41,10 @@ itself; enabled rules go from 351 to 565. The findings that surfaced are fixed â
 `re.DOTALL` spelled out in place of `re.S`, `str.removesuffix` and `min()` in
 `scripts/mcp_swap.py`, the server instruction blob built as an f-string, and the
 wrapped marker fixtures parenthesized so a dropped comma can no longer pass for
-a deliberate join. Two rules are scoped ignores with their reasons recorded in
+a deliberate join. `scripts/mcp_swap.py` is now executable and its shebang points
+at `uv run --script`, so running it directly honours the PEP 723 metadata instead
+of failing to import `tomlkit` under a bare `python3`. Two rules are scoped
+ignores with their reasons recorded in
 `pyproject.toml`: `exec` in `docs/conf.py`, which is how Sphinx reads version
 metadata, and the `except Exception` boundaries in the error middleware, the
 batch runners, the best-effort tmux probes, and `mcp_swap`'s config rollback.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,10 +136,6 @@ sphinx-gp-sitemap = false
 sphinx-gp-theme = false
 sphinx-ux-autodoc-layout = false
 sphinx-ux-badges = false
-# TEMPORARY - REVERT BEFORE MERGE. ruff 0.16.0 released 2026-07-23 and is
-# still inside the 3-day cooldown, so the resolver cannot see it. Drop this
-# line once the cooldown clears; the version floor is what holds ruff 0.16.
-ruff = false
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,10 @@ sphinx-gp-sitemap = false
 sphinx-gp-theme = false
 sphinx-ux-autodoc-layout = false
 sphinx-ux-badges = false
+# TEMPORARY - REVERT BEFORE MERGE. ruff 0.16.0 released 2026-07-23 and is
+# still inside the 3-day cooldown, so the resolver cannot see it. Drop this
+# line once the cooldown clears; the version floor is what holds ruff 0.16.
+ruff = false
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,6 +244,26 @@ convention = "numpy"
 # version metadata without importing the package (and its dependencies)
 # into the docs build. The path is a repo-local file, not user input.
 "docs/conf.py" = ["S102"]
+# Boundary catch-alls. Every `except Exception` in these files converts
+# an arbitrary failure into a reported result or a debug log instead of
+# letting it escape a place that cannot report it:
+#   middleware.py     the MCP error boundary, renders any tool exception
+#                     as an `is_error` result
+#   batch_tools.py    isolates one failed operation from its batch
+#   pane_tools/io.py  same, per send_keys operation
+#   server.py         best-effort buffer GC during lifespan shutdown
+#   server_tools.py   best-effort tmux metadata probes over sockets that
+#                     may be stale, denied, or running an old tmux
+#   mcp_swap.py       restores a CLI config's original bytes when a
+#                     write fails
+# tmux and the CLI configs fail in more ways than a narrowed clause can
+# enumerate, so narrowing here trades a logged degradation for a crash.
+"scripts/mcp_swap.py" = ["BLE001"]
+"src/libtmux_mcp/middleware.py" = ["BLE001"]
+"src/libtmux_mcp/server.py" = ["BLE001"]
+"src/libtmux_mcp/tools/batch_tools.py" = ["BLE001"]
+"src/libtmux_mcp/tools/pane_tools/io.py" = ["BLE001"]
+"src/libtmux_mcp/tools/server_tools.py" = ["BLE001"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,10 @@ exclude_lines = [
 target-version = "py310"
 
 [tool.ruff.lint]
-select = [
+# `select` is deliberately unset: ruff 0.16 enables a curated default rule
+# set, and an explicit `select` would replace it rather than extend it.
+# `extend-select` layers this project's additional linters on top.
+extend-select = [
   "E", # pycodestyle
   "F", # pyflakes
   "I", # isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dev = [
   "coverage",
   "pytest-cov",
   # Lint
-  "ruff",
+  "ruff>=0.16.0",
   "mypy",
 ]
 
@@ -103,7 +103,7 @@ coverage =[
 ]
 lint = [
   "typing-extensions; python_version < '3.11'",
-  "ruff",
+  "ruff>=0.16.0",
   "mypy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,10 @@ convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
 "*/__init__.py" = ["F401"]
+# The Sphinx conf idiom: `exec` the package's `__about__.py` to read
+# version metadata without importing the package (and its dependencies)
+# into the docs build. The path is a repo-local file, not user input.
+"docs/conf.py" = ["S102"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
 # dependencies = ["tomlkit>=0.13"]

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -648,7 +648,7 @@ def resolve_repo_meta(repo: pathlib.Path) -> tuple[str, str]:
         msg = f"{pyproject} has no [project] table"
         raise RuntimeError(msg)
     name = str(project["name"])
-    server = name[: -len("-mcp")] if name.endswith("-mcp") else name
+    server = name.removesuffix("-mcp")
     scripts = project.get("scripts") or {}
     if not scripts:
         msg = f"{pyproject} has no [project.scripts] — cannot derive entry"

--- a/scripts/mcp_swap.py
+++ b/scripts/mcp_swap.py
@@ -1187,7 +1187,7 @@ def _naming_hint(repo: pathlib.Path, server: str) -> str | None:
                 names.add(name)
     if server_points or not names:
         return None
-    pick = sorted(names)[0]
+    pick = min(names)
     return (
         f"note: nothing is registered under server {server!r}, but this repo is "
         f"registered as {sorted(names)} — pass --server {pick} to target it"
@@ -1237,7 +1237,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         print("    (no CLI currently points at this repo)")
 
     if all_repo_names and server not in all_repo_names:
-        pick = sorted(all_repo_names)[0]
+        pick = min(all_repo_names)
         print(
             f"  ! server name mismatch: this repo is registered as "
             f"{sorted(all_repo_names)}, not {server!r} — use --server {pick}"

--- a/src/libtmux_mcp/server.py
+++ b/src/libtmux_mcp/server.py
@@ -128,16 +128,14 @@ _INSTR_BUFFERS_GAP = (
     "clipboard history."
 )
 
-_BASE_INSTRUCTIONS = "\n\n".join(
-    (
-        _INSTR_HIERARCHY,
-        _INSTR_SCOPE,
-        _INSTR_METADATA_VS_CONTENT,
-        _INSTR_READ_TOOLS,
-        _INSTR_WAIT_NOT_POLL,
-        _INSTR_HOOKS_GAP,
-        _INSTR_BUFFERS_GAP,
-    )
+_BASE_INSTRUCTIONS = (
+    f"{_INSTR_HIERARCHY}\n\n"
+    f"{_INSTR_SCOPE}\n\n"
+    f"{_INSTR_METADATA_VS_CONTENT}\n\n"
+    f"{_INSTR_READ_TOOLS}\n\n"
+    f"{_INSTR_WAIT_NOT_POLL}\n\n"
+    f"{_INSTR_HOOKS_GAP}\n\n"
+    f"{_INSTR_BUFFERS_GAP}"
 )
 
 _INSTRUCTIONS_MAX_BYTES = 2048

--- a/tests/test_pane_tools.py
+++ b/tests/test_pane_tools.py
@@ -980,10 +980,14 @@ FILTER_DROP_FIXTURES: list[FilterDropFixture] = [
         "current_wrapped_long_marker",
         [
             "RUN_OK",
-            "∙ }; __libtmux_mcp_status=$?; tmux set-option -p "
-            f"@libtmux_mcp_status_{_CURRENT_ID[:10]}",
-            f'{_CURRENT_ID[10:]} "$__libtmux_mcp_status"; '
-            "tmux wait-for -S libtmux_mcp_run_",
+            (
+                "∙ }; __libtmux_mcp_status=$?; tmux set-option -p "
+                f"@libtmux_mcp_status_{_CURRENT_ID[:10]}"
+            ),
+            (
+                f'{_CURRENT_ID[10:]} "$__libtmux_mcp_status"; '
+                "tmux wait-for -S libtmux_mcp_run_"
+            ),
             _CURRENT_ID,
         ],
         f"libtmux_mcp_run_{_CURRENT_ID}",
@@ -993,10 +997,14 @@ FILTER_DROP_FIXTURES: list[FilterDropFixture] = [
         "previous_wrapped_long_marker",
         [
             "RUN_OK",
-            "∙ }; __libtmux_mcp_status=$?; tmux set-option -p "
-            f"@libtmux_mcp_status_{_PREVIOUS_ID[:10]}",
-            f'{_PREVIOUS_ID[10:]} "$__libtmux_mcp_status"; '
-            "tmux wait-for -S libtmux_mcp_run_",
+            (
+                "∙ }; __libtmux_mcp_status=$?; tmux set-option -p "
+                f"@libtmux_mcp_status_{_PREVIOUS_ID[:10]}"
+            ),
+            (
+                f'{_PREVIOUS_ID[10:]} "$__libtmux_mcp_status"; '
+                "tmux wait-for -S libtmux_mcp_run_"
+            ),
             _PREVIOUS_ID,
         ],
         f"libtmux_mcp_run_{_CURRENT_ID}",
@@ -1006,8 +1014,10 @@ FILTER_DROP_FIXTURES: list[FilterDropFixture] = [
         "current_short_marker",
         [
             "RUN_OK",
-            f'∙ }}; s=$?; tmux set-option -p @s_{_SHORT_CURRENT_ID} "$s"; '
-            f"tmux wait-for -S r_{_SHORT_CURRENT_ID}",
+            (
+                f'∙ }}; s=$?; tmux set-option -p @s_{_SHORT_CURRENT_ID} "$s"; '
+                f"tmux wait-for -S r_{_SHORT_CURRENT_ID}"
+            ),
         ],
         f"r_{_SHORT_CURRENT_ID}",
         f"@s_{_SHORT_CURRENT_ID}",

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -438,7 +438,7 @@ def test_docs_sample_render_matches_the_server(mcp_with_prompts: FastMCP) -> Non
     block = re.search(
         r'\*\*Sample render\*\* \(``pane_id="%1"``\):\n\n````markdown\n(.*?)````',
         page.read_text(),
-        re.S,
+        re.DOTALL,
     )
     assert block is not None, "interrupt_gracefully sample-render block not found"
 

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,7 @@ sphinx-ux-badges = false
 gp-libs = false
 sphinx-autodoc-docutils = false
 gp-furo-theme = false
+ruff = false
 sphinx-gp-sitemap = false
 sphinx-fonts = false
 sphinx-autodoc-typehints-gp = false
@@ -1265,7 +1266,7 @@ dev = [
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
     { name = "pytest-xdist" },
-    { name = "ruff" },
+    { name = "ruff", specifier = ">=0.16.0" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a36" },
     { name = "sphinx-autodoc-fastmcp", specifier = "==0.0.1a36" },
@@ -1282,7 +1283,7 @@ docs = [
 ]
 lint = [
     { name = "mypy" },
-    { name = "ruff" },
+    { name = "ruff", specifier = ">=0.16.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 testing = [
@@ -2417,27 +2418,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.22"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,6 @@ sphinx-ux-badges = false
 gp-libs = false
 sphinx-autodoc-docutils = false
 gp-furo-theme = false
-ruff = false
 sphinx-gp-sitemap = false
 sphinx-fonts = false
 sphinx-autodoc-typehints-gp = false


### PR DESCRIPTION
## Summary

- **Bump** the `ruff` floor to `>=0.16.0` in the `dev` and `lint` dependency groups so contributors and CI see the same diagnostics instead of splitting on whatever ruff each machine happened to resolve.
- **Adopt** ruff's own curated default rule set by moving `[tool.ruff.lint]` from `select` to `extend-select`. An explicit `select` *replaces* the default set rather than adding to it, so this project had been silently opting out of every rule it did not name itself. Enabled rules go from 351 to 565.
- **Fix** the six real findings that surfaced, one rule per commit, and **scope** the two intentional ones as per-file ignores with the reason recorded in `pyproject.toml`.

## Why `extend-select`

ruff 0.16 ships a curated default rule set as its recommended baseline. There is no token that names that set from inside `select` — the selector grammar has `ALL`, prefixes, and individual codes, and nothing else — so a config with an explicit `select` cannot say "the defaults, plus these". Leaving `select` unset and layering the project's own linters on with `extend-select` is the only way to get defaults-plus-extras. The file carries a comment saying so, because the natural instinct on reading it is to "tidy" `extend-select` back into `select`.

Expanding to whole prefixes instead was considered and rejected: it drags in all of `D`, `PL`, `S`, and friends rather than ruff's curated subset, and is one to two orders of magnitude noisier for no corresponding gain in signal.

## Findings fixed

[`FURB167`](https://docs.astral.sh/ruff/rules/regex-flag-alias/) — `re.S` spelled out as `re.DOTALL` in the docs-drift test.

[`FURB188`](https://docs.astral.sh/ruff/rules/slice-to-remove-prefix-or-suffix/) — `mcp_swap` derived the server name with a conditional slice that restated the `-mcp` suffix twice and depended on `-len()` arithmetic staying in sync with its own `endswith` guard. Now `str.removesuffix`.

[`FURB192`](https://docs.astral.sh/ruff/rules/sorted-min-max/) — `mcp_swap` sorted a whole set of registered server names to read the first element, twice, both times to suggest a `--server` value. Now `min`.

[`FLY002`](https://docs.astral.sh/ruff/rules/static-join-to-f-string/) — the server's base instruction blob joined a static tuple of sections. ruff's own fix collapses the sections onto a single over-long line and trades the finding for an `E501`, so this one is hand-written instead: an f-string with one section per line, which reads the same as the tuple did.

[`ISC004`](https://docs.astral.sh/ruff/rules/implicit-string-concatenation-in-collection-literal/) — the `run_command` marker-filtering fixtures build captured pane lines as multi-line implicit concatenations inside a list. Element boundaries are exactly what those fixtures test, and unparenthesized concatenation makes a dropped comma indistinguishable from a deliberate join. Parenthesized, matching the form one fixture in the same literal already used.

[`EXE001`](https://docs.astral.sh/ruff/rules/shebang-not-executable/) — `scripts/mcp_swap.py` carried a shebang without the executable bit, and the interpreter it named was wrong besides: it is a PEP 723 script whose inline metadata declares `tomlkit`, so direct execution under bare `python3` raised `ModuleNotFoundError`. The shebang now points at `uv run --script`, which honours that metadata, and the bit is set in the index. `uv run scripts/mcp_swap.py` and the `just mcp-*` recipes are unchanged. Worth flagging for anyone reproducing this locally: ruff does not enforce `EXE001` on WSL, so this one surfaced only on CI.

## Findings scoped as ignores

[`S102`](https://docs.astral.sh/ruff/rules/exec-builtin/) in `docs/conf.py` — the Sphinx idiom of `exec`ing the package's `__about__.py` to read version metadata without importing the package into the docs build. A repo-local file, no user input. Scoped to that one file so a stray `exec` anywhere else still fails the lint.

[`BLE001`](https://docs.astral.sh/ruff/rules/blind-except/) in six files — every site was read individually, and all of them are deliberate boundaries: the MCP error middleware that renders any tool exception as an `is_error` result, the per-operation isolation in the tool and send-keys batch runners, the best-effort tmux version probes and lifespan buffer GC, and `mcp_swap`'s rollback to a config's original bytes when a write fails. tmux and the agent CLIs' config files fail in more ways than a narrowed clause can enumerate, so narrowing here would trade a logged degradation for a crash in code whose whole job is not to crash. `BLE001` stays enforced everywhere else.

## Design decisions

**Floor, not pin.** `>=0.16.0` is what holds the version: it guarantees every contributor is at or past the release that changes formatting behavior, while still letting them take later patch releases. `uv.lock` pins the exact version CI resolves.

**One commit per rule.** Each fixed rule and each added ignore is its own commit, so a rule can be reverted or re-argued without unpicking the rest, and each commit body carries the rule's documentation link.

**No `noqa`, no explanatory code comments.** Intentional idioms are declared in the ruff config, where the next reader of the config finds them, rather than annotated at the call site.

**Markdown formatting is a no-op here.** 0.16.0 makes `ruff format` format Python and pycon code blocks inside Markdown by default, so the README and the `docs/` tree are now in scope. Every Markdown file in this repo is already formatted the way ruff wants it, so `ruff format --check .` passes across the wider file set with no churn.

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — every file already formatted (Python plus Markdown code blocks)
- [x] `uv run mypy` — no issues found
- [x] `uv run pytest` — full suite green
- [x] Enabled-rule count confirmed against `ruff check --show-settings .` before and after the config change
