### PR TITLE
Track the FastMCP 4 prerelease line

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,15 @@ or as a bare name carrying only its type.
 
 ### Development
 
+**The test suite runs without FastMCP's camelCase compatibility shims**
+
+FastMCP still answers MCP SDK v1 attribute spellings through warn-once
+shims it plans to remove. Neither gate catches a test that depends on one:
+the type checker sees `Any`, and the warning fires once per attribute for a
+whole run. The suite now disables the shims, so a read that needs them
+fails the test that made it, and tests read argument schemas under the name
+that goes on the wire instead.
+
 #### CI actions updated to current majors
 
 Workflow actions moved to their current major releases: `actions/checkout` v7,

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,28 @@
 _Notes on upcoming releases will be added here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+**Minimum `fastmcp>=4.0.0b2`** (was `>=3.4.2`)
+
+libtmux-mcp now tracks the FastMCP 4 prerelease line. The requirement is a
+floor rather than an exact pin, so installs pick up 4.0.0 once it ships
+without another release here. FastMCP 4 builds on MCP Python SDK v2, which
+brings `mcp>=2.0.0` and pydantic 2.12 with it; no tool, resource, or prompt
+changes shape, and servers serve the same protocol eras their clients ask
+for.
+
+**`tmux://` reads keep accepting tmux names that look like paths**
+
+FastMCP 4 screens templated resource parameters before a handler runs.
+Its absolute-path check does not fit tmux identifiers: it rejects the
+socket paths {tooliconl}`list-servers` reports, and reads any
+`<letter>:<rest>` session name — which tmux accepts — as a Windows
+drive-relative path. Both stay readable, so `tmux://` and the equivalent
+tools continue to agree on which sessions and servers exist. Traversal and
+null-byte screening remain on, where they still guard `socket_name` on its
+way to `tmux -L`.
+
 ### Documentation
 
 #### Caller identity fields are described (#105)

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ https://docs.pytest.org/en/stable/deprecations.html
 
 from __future__ import annotations
 
+import os
 import shutil
 import typing as t
 
@@ -23,6 +24,21 @@ from libtmux.window import Window
 
 if t.TYPE_CHECKING:
     import pathlib
+
+# Run the suite with fastmcp's camelCase compatibility bridge switched
+# off. fastmcp 4 still answers SDK v1 spellings like `tool.inputSchema`
+# through warn-once shims that are scheduled for removal, and neither
+# gate catches a read that depends on them: mypy sees `Any` (the SDK
+# objects arrive through `Client.__aenter__`, which is unannotated) and
+# the warning fires once per (class, attribute) for the whole run, so
+# one stray read is easy to miss. With the bridge off a surviving read
+# raises `AttributeError` and fails the test that made it.
+#
+# Set before anything imports fastmcp — its settings singleton is built
+# at import — and via the environment rather than the settings object so
+# the subprocess-based tests inherit it through `os.environ.copy()`.
+# `test_camelcase_bridge_is_disabled_for_the_suite` asserts it took.
+os.environ.setdefault("FASTMCP_MCP_CAMELCASE_COMPAT", "false")
 
 pytest_plugins = ["pytester", "sphinx.testing.fixtures"]
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -24,8 +24,8 @@
 
 | Package | Required version |
 |---------|-----------------|
-| [libtmux](https://libtmux.git-pull.com/) | >= 0.55.0, < 1.0 |
-| [FastMCP](https://github.com/jlowin/fastmcp) | >= 3.1.0, < 4.0.0 |
+| [libtmux](https://libtmux.git-pull.com/) | >= 0.62.0, < 1.0 |
+| [FastMCP](https://github.com/jlowin/fastmcp) | >= 3.4.2, < 4.0.0 |
 
 ## MCP clients
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -25,7 +25,7 @@
 | Package | Required version |
 |---------|-----------------|
 | [libtmux](https://libtmux.git-pull.com/) | >= 0.62.0, < 1.0 |
-| [FastMCP](https://github.com/jlowin/fastmcp) | >= 3.4.2, < 4.0.0 |
+| [FastMCP](https://github.com/jlowin/fastmcp) | >= 4.0.0b2, < 5.0.0 |
 
 ## MCP clients
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ include = [
 
 dependencies = [
   "libtmux>=0.62.0,<1.0",
-  "fastmcp>=3.4.2,<4.0.0",
+  "fastmcp>=4.0.0b2,<5.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ dev = [
   "syrupy>=5.1.0",
   # scripts/mcp_swap.py (PEP 723 script; dep listed here so tests can import it)
   "tomlkit>=0.13",
+  # Arrives transitively via pytest, but tests/docs/test_compatibility.py
+  # imports it directly to compare version ranges rather than strings.
+  "packaging",
   # Coverage
   "codecov",
   "coverage",

--- a/src/libtmux_mcp/middleware.py
+++ b/src/libtmux_mcp/middleware.py
@@ -360,9 +360,13 @@ class ToolErrorResultMiddleware(ErrorHandlingMiddleware):
     intercepts tool-call exceptions first (``on_call_tool`` is the
     innermost hook of a middleware's chain) and returns
     :func:`_error_tool_result` instead; non-tool messages fall through
-    to the inherited ``on_message``, preserving the MCP ``-32002``
-    resource-not-found transform this middleware was originally
-    adopted for.
+    to the inherited ``on_message``.
+
+    That inherited transform maps only the not-found exception types
+    fastmcp matches exactly (:exc:`FileNotFoundError`, :exc:`KeyError`,
+    ``NotFoundError``) to MCP ``-32002``. The ``tmux://`` resources
+    raise :exc:`~fastmcp.exceptions.ResourceError`, which is none of
+    them, so a missing session reaches the client as ``-32603``.
 
     Logging honors ``FastMCPError.log_level`` (fastmcp >= 3.3): the
     expected failures demoted to WARNING by

--- a/src/libtmux_mcp/middleware.py
+++ b/src/libtmux_mcp/middleware.py
@@ -38,7 +38,7 @@ from fastmcp.server.middleware.error_handling import (
     RetryMiddleware,
 )
 from fastmcp.server.middleware.response_limiting import ResponseLimitingMiddleware
-from fastmcp.tools.base import ToolResult
+from fastmcp.tools import ToolResult
 from libtmux import exc as libtmux_exc
 from mcp.types import CallToolRequestParams, TextContent
 from pydantic import ValidationError as PydanticValidationError

--- a/src/libtmux_mcp/server.py
+++ b/src/libtmux_mcp/server.py
@@ -370,8 +370,8 @@ mcp = FastMCP(
     #      ToolResult(is_error=True) here, so truncation preserves that
     #      flag instead of turning expected failures into schema errors.
     #   3. ToolErrorResultMiddleware — converts tool-call failures to
-    #      rich ToolResult(is_error=True) results and transforms
-    #      resource errors to MCP code -32002. Must stay OUTSIDE the
+    #      rich ToolResult(is_error=True) results and leaves non-tool
+    #      messages to the inherited transform. Must stay OUTSIDE the
     #      audit + retry + safety trio: all three depend on exception
     #      semantics (audit catches to record outcome=error, retry
     #      matches LibTmuxException via __cause__, and safety's tier

--- a/src/libtmux_mcp/server.py
+++ b/src/libtmux_mcp/server.py
@@ -12,6 +12,7 @@ import shutil
 import typing as t
 
 from fastmcp import FastMCP
+from fastmcp.resources import ResourceSecurity
 from fastmcp.server.middleware.timing import TimingMiddleware
 
 if t.TYPE_CHECKING:
@@ -362,6 +363,12 @@ mcp = FastMCP(
     ),
     website_url="https://libtmux-mcp.git-pull.com/",
     lifespan=_lifespan,
+    # No resource parameter is ever joined onto a path, so the absolute-path
+    # screen only misfires: on the socket paths list_servers hands back, and
+    # on `<letter>:<rest>` session names tmux accepts. Traversal screening
+    # stays on — socket_name reaches `tmux -L`, where `../..` really does
+    # place the socket outside the tmux socket directory.
+    resource_security=ResourceSecurity(reject_absolute_paths=False),
     # Middleware runs outermost-first. Order rationale:
     #   1. TimingMiddleware — neutral observer; start clock as early
     #      as possible so timing captures middleware cost too.

--- a/src/libtmux_mcp/tools/batch_tools.py
+++ b/src/libtmux_mcp/tools/batch_tools.py
@@ -7,7 +7,7 @@ import time
 import typing as t
 
 from fastmcp import Context
-from fastmcp.tools.base import ToolResult
+from fastmcp.tools import ToolResult
 from pydantic import BaseModel
 
 from libtmux_mcp._utils import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,3 +92,21 @@ def wire_annotations(tool: t.Any) -> dict[str, t.Any]:
         mode="json", by_alias=True, exclude_none=True
     )
     return dumped
+
+
+def wire_input_schema(tool: t.Any) -> dict[str, t.Any]:
+    """Return a tool's argument schema under its PROTOCOL name.
+
+    ``tool.inputSchema`` is the SDK v1 attribute spelling. SDK v2
+    renamed it to ``input_schema`` and fastmcp answers the old name
+    through a deprecation shim it plans to remove; the suite runs with
+    that shim disabled (see the root ``conftest.py``), so the camelCase
+    read is an ``AttributeError`` here.
+
+    Dumping ``by_alias=True`` reads the name that goes on the wire,
+    which is what a client sees and what the protocol guarantees.
+    Sibling of :func:`wire_annotations`.
+    """
+    dumped: dict[str, t.Any] = tool.model_dump(mode="json", by_alias=True)
+    schema: dict[str, t.Any] = dumped["inputSchema"]
+    return schema

--- a/tests/docs/conftest.py
+++ b/tests/docs/conftest.py
@@ -28,6 +28,12 @@ def docs_dir() -> pathlib.Path:
 
 
 @pytest.fixture
+def repo_root() -> pathlib.Path:
+    """Absolute path to the repository checkout."""
+    return _REPO_ROOT
+
+
+@pytest.fixture
 def real_widget_srcdir(tmp_path: pathlib.Path, docs_dir: pathlib.Path) -> pathlib.Path:
     """Minimal Sphinx srcdir pre-populated with the real ``mcp-install`` widget."""
     srcdir = tmp_path / "src"

--- a/tests/docs/test_compatibility.py
+++ b/tests/docs/test_compatibility.py
@@ -1,0 +1,93 @@
+"""Tests keeping the compatibility reference in step with the manifest.
+
+The dependency table in ``docs/reference/compatibility.md`` restates
+floors that live in ``pyproject.toml``. Nothing regenerates it, so it
+drifts silently every time a floor moves — a reader planning an upgrade
+gets a number the resolver will never agree with.
+
+Specifiers are compared as :class:`~packaging.specifiers.SpecifierSet`
+values rather than as strings, so the doc stays free to write
+``>= 0.62.0, < 1.0`` where the manifest writes ``>=0.62.0,<1.0``.
+"""
+
+from __future__ import annotations
+
+import re
+import typing as t
+
+import pytest
+import tomlkit
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import NormalizedName, canonicalize_name
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+#: Heading of the table that restates ``[project].dependencies``.
+_DEPENDENCIES_HEADING = "Dependencies"
+
+#: A Markdown link; its text is the human-facing package name, which may
+#: be capitalized differently from the distribution ("FastMCP").
+_LINK = re.compile(r"\[([^\]]+)\]\([^)]*\)")
+
+
+def _section_body(text: str, heading: str) -> str:
+    """Return the body of a ``##`` section, up to the next one."""
+    for chunk in re.split(r"^## ", text, flags=re.MULTILINE)[1:]:
+        title, _, body = chunk.partition("\n")
+        if title.strip() == heading:
+            return body
+    pytest.fail(f"compatibility.md has no '## {heading}' section")
+
+
+def _table_rows(body: str) -> list[list[str]]:
+    """Return the data rows of the first Markdown table in ``body``."""
+    rows = [
+        [cell.strip() for cell in line.strip().strip("|").split("|")]
+        for line in body.splitlines()
+        if line.strip().startswith("|")
+    ]
+    # Drop the header and its `|---|---|` separator.
+    return [row for row in rows[2:] if row]
+
+
+def _documented_floors(text: str) -> dict[NormalizedName, SpecifierSet]:
+    """Return the dependency table keyed by canonical package name."""
+    body = _section_body(text, _DEPENDENCIES_HEADING)
+    documented = {}
+    for name_cell, version_cell, *_ in _table_rows(body):
+        link = _LINK.search(name_cell)
+        name = link.group(1) if link else name_cell
+        documented[canonicalize_name(name)] = SpecifierSet(version_cell)
+    return documented
+
+
+def _declared_floors(repo_root: pathlib.Path) -> dict[NormalizedName, SpecifierSet]:
+    """Return ``[project].dependencies`` keyed by canonical package name."""
+    manifest = tomlkit.loads(
+        (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    ).unwrap()
+    requirements = [Requirement(spec) for spec in manifest["project"]["dependencies"]]
+    return {canonicalize_name(req.name): req.specifier for req in requirements}
+
+
+def test_compatibility_documents_every_runtime_dependency(
+    docs_dir: pathlib.Path,
+    repo_root: pathlib.Path,
+) -> None:
+    """The dependency table lists exactly what the project requires."""
+    text = (docs_dir / "reference" / "compatibility.md").read_text(encoding="utf-8")
+
+    assert set(_documented_floors(text)) == set(_declared_floors(repo_root))
+
+
+def test_compatibility_dependency_floors_match_the_manifest(
+    docs_dir: pathlib.Path,
+    repo_root: pathlib.Path,
+) -> None:
+    """Each documented version range is the range the resolver enforces."""
+    text = (docs_dir / "reference" / "compatibility.md").read_text(encoding="utf-8")
+    documented = _documented_floors(text)
+
+    assert documented == _declared_floors(repo_root)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -17,6 +17,8 @@ import pytest
 from fastmcp import Client, FastMCP
 from libtmux.test.retry import retry_until
 
+from tests.conftest import wire_input_schema
+
 if t.TYPE_CHECKING:
     from libtmux.pane import Pane
     from libtmux.server import Server
@@ -136,7 +138,7 @@ def test_history_transform_changes_exact_semantic_tool_set() -> None:
             tools = await client.list_tools()
         schemas: dict[str, dict[str, t.Any]] = {}
         for tool in tools:
-            properties = tool.inputSchema["properties"]
+            properties = wire_input_schema(tool)["properties"]
             if tool.name in spawn_tools:
                 assert "suppress_history" not in properties
                 schemas[tool.name] = properties["suppress_persistent_history"]
@@ -351,6 +353,15 @@ def test_production_mcp_schema_scopes_startup_default_to_run_command(
 
         logging.disable(logging.CRITICAL)
 
+        # by_alias=True dumps the WIRE names. Without it these read the
+        # SDK's Python attribute spelling, which is camelCase on mcp 1.x
+        # and snake_case on 2.x -- so the assertions below would break on
+        # an SDK upgrade while the protocol output was unchanged. Mirrors
+        # tests/conftest.py's wire_input_schema / wire_annotations, which
+        # this subprocess cannot import without pulling in pytest.
+        def schema_of(tool):
+            return tool.model_dump(mode="json", by_alias=True)["inputSchema"]
+
         async def main():
             first = build_mcp_server()
             before = len(first.transforms)
@@ -359,30 +370,24 @@ def test_production_mcp_schema_scopes_startup_default_to_run_command(
             async with Client(first) as client:
                 tools = {tool.name: tool for tool in await client.list_tools()}
             tool = tools["run_command"]
-            schema = tool.inputSchema["properties"]["suppress_history"]
+            schema = schema_of(tool)["properties"]["suppress_history"]
             print(json.dumps({
                 "same_server": first is second,
                 "transform_counts": [before, after],
                 "schema": schema,
-                # by_alias=True dumps the WIRE names. Without it this
-                # asserts the SDK's Python attribute spelling, which is
-                # camelCase on mcp 1.x and snake_case on 2.x -- so the
-                # assertion below would break on an SDK upgrade while
-                # the protocol output was unchanged. Matches the
-                # by_alias=True already used in tools/batch_tools.py.
                 "annotations": tool.annotations.model_dump(
                     mode="json", exclude_none=True, by_alias=True
                 ),
                 "tags": tool.meta["fastmcp"]["tags"],
                 "raw_defaults": {
-                    "send_keys": tools["send_keys"].inputSchema["properties"]
+                    "send_keys": schema_of(tools["send_keys"])["properties"]
                     ["suppress_history"]["default"],
-                    "send_keys_batch": tools["send_keys_batch"].inputSchema
+                    "send_keys_batch": schema_of(tools["send_keys_batch"])
                     ["properties"]["operations"]["items"]["properties"]
                     ["suppress_history"]["default"],
                 },
                 "spawn_defaults": {
-                    name: tools[name].inputSchema["properties"]
+                    name: schema_of(tools[name])["properties"]
                     ["suppress_persistent_history"]["default"]
                     for name in (
                         "create_session",
@@ -392,7 +397,7 @@ def test_production_mcp_schema_scopes_startup_default_to_run_command(
                     )
                 },
                 "spawn_descriptions": {
-                    name: tools[name].inputSchema["properties"]
+                    name: schema_of(tools[name])["properties"]
                     ["suppress_persistent_history"]["description"]
                     for name in (
                         "create_session",
@@ -646,9 +651,9 @@ def test_global_history_transform_keeps_raw_and_paste_schemas_explicit_only() ->
             return {tool.name: tool for tool in await client.list_tools()}
 
     tools = asyncio.run(_list_tools())
-    run_command = tools["run_command"].inputSchema["properties"]
-    send_keys = tools["send_keys"].inputSchema["properties"]
-    operation = tools["send_keys_batch"].inputSchema["properties"]["operations"][
+    run_command = wire_input_schema(tools["run_command"])["properties"]
+    send_keys = wire_input_schema(tools["send_keys"])["properties"]
+    operation = wire_input_schema(tools["send_keys_batch"])["properties"]["operations"][
         "items"
     ]["properties"]
 
@@ -657,8 +662,11 @@ def test_global_history_transform_keeps_raw_and_paste_schemas_explicit_only() ->
     assert "anyOf" not in run_command["suppress_history"]
     assert send_keys["suppress_history"]["default"] is False
     assert operation["suppress_history"]["default"] is False
-    assert "suppress_history" not in tools["paste_text"].inputSchema["properties"]
-    assert "suppress_history" not in tools["paste_buffer"].inputSchema["properties"]
+    paste_text = wire_input_schema(tools["paste_text"])["properties"]
+    paste_buffer = wire_input_schema(tools["paste_buffer"])["properties"]
+
+    assert "suppress_history" not in paste_text
+    assert "suppress_history" not in paste_buffer
 
 
 def test_global_history_default_leaves_raw_send_keys_bytes_and_boundaries(

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -676,12 +676,14 @@ def test_server_middleware_stack_order() -> None:
 def test_error_handling_middleware_transforms_errors() -> None:
     """ToolErrorResultMiddleware is configured with transform_errors=True.
 
-    Regression guard: without ``transform_errors=True`` the inherited
-    ``on_message`` would still log but not map resource errors to MCP
-    error code ``-32002``, which is the protocol-correctness point of
-    keeping the ErrorHandlingMiddleware base for non-tool messages
-    (tool-call errors are converted to ``is_error`` results before
-    they reach ``on_message``).
+    Regression guard for the inherited ``on_message`` transform, which
+    non-tool messages still rely on. Tool-call errors never reach it —
+    they become ``is_error`` results first.
+
+    This asserts the flag, not a wire code: the transform maps only the
+    not-found types fastmcp matches exactly, and the ``tmux://``
+    resources raise :exc:`~fastmcp.exceptions.ResourceError`, so a
+    missing session surfaces as ``-32603`` rather than ``-32002``.
     """
     from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 

--- a/tests/test_resources_integration.py
+++ b/tests/test_resources_integration.py
@@ -8,8 +8,11 @@ import typing as t
 
 import pytest
 from fastmcp import Client
+from mcp.shared.exceptions import MCPError
 
+from libtmux_mcp._utils import _server_cache
 from libtmux_mcp.server import _register_all, mcp
+from libtmux_mcp.tools.session_tools import get_session_info
 
 if t.TYPE_CHECKING:
     from libtmux.pane import Pane
@@ -117,3 +120,142 @@ def test_resource_read_via_client(
 
     if expect_contains is not None:
         assert expect_contains in text
+
+
+# ---------------------------------------------------------------------------
+# Path-like parameter values.
+#
+# Every ``tmux://`` template carries ``{?socket_name}``, and two of its
+# parameters routinely hold values a generic screen reads as filesystem
+# paths: a socket path is absolute, and tmux accepts session names such
+# as ``a:1`` that look drive-relative. Neither is ever joined onto a
+# path, so both must reach the handler — while a ``..`` component, which
+# really does escape tmux's socket directory, must not.
+#
+# Sessions are created and renamed with raw tmux: libtmux's own
+# ``new_session`` and ``rename_session`` reject colons and periods, so
+# going through them would hide exactly what these guard.
+# ---------------------------------------------------------------------------
+
+#: A session name that is legal in tmux and path-shaped to a screen.
+PATH_LIKE_SESSION_NAME = "a:1"
+
+
+def _socket_path(server: Server) -> str:
+    """Return the absolute socket path a server is listening on.
+
+    This is the spelling ``list_servers`` reports, so it is the value a
+    client is most likely to send back.
+    """
+    return server.cmd("display-message", "-p", "#{socket_path}").stdout[0]
+
+
+class PathLikeResourceFixture(t.NamedTuple):
+    """A ``tmux://`` template read with path-like parameter values.
+
+    Attributes
+    ----------
+    test_id : str
+        Identifier shown in the parametrized test name.
+    uri_template : str
+        ``tmux://`` URI with ``{}`` placeholders for the tmux targets.
+    """
+
+    test_id: str
+    uri_template: str
+
+
+PATH_LIKE_RESOURCE_FIXTURES: list[PathLikeResourceFixture] = [
+    PathLikeResourceFixture(
+        "all_sessions",
+        "tmux://sessions?socket_name={socket_path}",
+    ),
+    PathLikeResourceFixture(
+        "session_detail",
+        "tmux://sessions/{session_name}?socket_name={socket_path}",
+    ),
+    PathLikeResourceFixture(
+        "session_windows",
+        "tmux://sessions/{session_name}/windows?socket_name={socket_path}",
+    ),
+    PathLikeResourceFixture(
+        "window_detail",
+        "tmux://sessions/{session_name}/windows/{window_index}"
+        "?socket_name={socket_path}",
+    ),
+    PathLikeResourceFixture(
+        "pane_detail",
+        "tmux://panes/{pane_id}?socket_name={socket_path}",
+    ),
+    PathLikeResourceFixture(
+        "pane_content",
+        "tmux://panes/{pane_id}/content?socket_name={socket_path}",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    PathLikeResourceFixture._fields,
+    PATH_LIKE_RESOURCE_FIXTURES,
+    ids=[f.test_id for f in PATH_LIKE_RESOURCE_FIXTURES],
+)
+def test_resource_read_accepts_path_like_parameters(
+    mcp_server: Server,
+    mcp_session: Session,
+    mcp_window: Window,
+    mcp_pane: Pane,
+    test_id: str,
+    uri_template: str,
+) -> None:
+    """Every template stays readable with an absolute socket and ``a:1``."""
+    assert test_id
+    mcp_server.cmd(
+        "rename-session",
+        "-t",
+        mcp_session.session_id,
+        PATH_LIKE_SESSION_NAME,
+    )
+    socket_path = _socket_path(mcp_server)
+    _server_cache[(socket_path, None, None)] = mcp_server
+
+    uri = uri_template.format(
+        session_name=PATH_LIKE_SESSION_NAME,
+        window_index=mcp_window.window_index,
+        pane_id=mcp_pane.pane_id,
+        socket_path=socket_path,
+    )
+
+    assert isinstance(_run(_read(uri)), str)
+
+
+@pytest.mark.parametrize("session_name", ["a:1", "x:", "a..b"])
+def test_resource_and_tool_agree_on_path_like_session_names(
+    mcp_server: Server,
+    session_name: str,
+) -> None:
+    """A session readable through a tool is readable through ``tmux://``."""
+    mcp_server.cmd("new-session", "-d", "-s", session_name)
+
+    payload = json.loads(_run(_read(f"tmux://sessions/{session_name}")))
+    info = get_session_info(
+        session_name=session_name,
+        socket_name=mcp_server.socket_name,
+    )
+
+    assert payload["session_name"] == session_name == info.session_name
+
+
+def test_socket_name_traversal_never_reaches_tmux() -> None:
+    """A ``..`` socket name is refused before a server is built for it.
+
+    tmux appends a ``-L`` value to its socket directory without
+    normalising it, so ``../..`` puts the socket somewhere else
+    entirely. URI normalization does not help: it collapses ``..`` in
+    the path, not in the query string.
+    """
+    socket_name = "../../escaped"
+
+    with pytest.raises(MCPError):
+        _run(_read(f"tmux://sessions?socket_name={socket_name}"))
+
+    assert (socket_name, None, None) not in _server_cache

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -744,6 +744,19 @@ def test_server_advertised_as_tmux() -> None:
     assert mcp.name == "tmux"
 
 
+def test_camelcase_bridge_is_disabled_for_the_suite() -> None:
+    """The suite runs without fastmcp's camelCase compatibility shims.
+
+    The root ``conftest.py`` clears the setting through the environment,
+    which only takes effect if nothing imported fastmcp first. Assert it
+    here so a future import-order change fails loudly instead of quietly
+    handing the suite back its safety net.
+    """
+    import fastmcp
+
+    assert fastmcp.settings.mcp_camelcase_compat is False
+
+
 def test_build_mcp_server_registers_catalog_idempotently() -> None:
     """The FastMCP factory returns a populated server every time."""
     import asyncio

--- a/tests/test_spawn_tools_history.py
+++ b/tests/test_spawn_tools_history.py
@@ -12,6 +12,8 @@ import pytest
 from fastmcp import Client, FastMCP
 from libtmux.test.retry import retry_until
 
+from tests.conftest import wire_input_schema
+
 if t.TYPE_CHECKING:
     from libtmux.pane import Pane
     from libtmux.server import Server
@@ -137,7 +139,7 @@ def test_spawn_environment_schemas_disclose_visibility() -> None:
     tools = asyncio.run(_list_tools())
 
     for name in ("create_window", "split_window"):
-        description = tools[name].inputSchema["properties"]["environment"][
+        description = wire_input_schema(tools[name])["properties"]["environment"][
             "description"
         ]
         for fragment in (
@@ -151,7 +153,7 @@ def test_spawn_environment_schemas_disclose_visibility() -> None:
         ):
             assert fragment in description
 
-    session_description = tools["create_session"].inputSchema["properties"][
+    session_description = wire_input_schema(tools["create_session"])["properties"][
         "environment"
     ]["description"]
     for fragment in (

--- a/uv.lock
+++ b/uv.lock
@@ -783,21 +783,22 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.6"
+version = "4.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/e2c78e26233cd8a416b21513e1925435d54c008a0ec467dbdaa80369daf7/fastmcp-3.4.6.tar.gz", hash = "sha256:2287938da8364ad7071bec2d2393af6ae10fd4e836f06f506569f1456cc87eb4", size = 28808130, upload-time = "2026-08-05T14:54:42.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/b1/a9270d6ddcfc85c26d0d5de8174c4c55abe28d1143b2bc5a78bbdb72c40e/fastmcp-4.0.0b2.tar.gz", hash = "sha256:e0f272a2677da9e3683c55e3274ceccdf9026116abc3bc8c6a56aa0ae6a323ce", size = 42134183, upload-time = "2026-08-07T00:18:24.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/a5/c02275db111892388972edbb05fbcbfdf1e83cbd1fd03356b3a49b93f839/fastmcp-3.4.6-py3-none-any.whl", hash = "sha256:2a29967be9f68cdd1b4cefb413ede74f83adefd923919a37aaac3611eccdd749", size = 8017, upload-time = "2026-08-05T14:54:38.473Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2f/535f9d1d6d2e5ba0e64d2e56ab92eb71dc6cd37af21f65696e566a8a6ad4/fastmcp-4.0.0b2-py3-none-any.whl", hash = "sha256:367eaf66444116b95c148cade3300f42b12c667ce38463743574c8c948fb5baf", size = 8086, upload-time = "2026-08-07T00:18:20.106Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.6"
+version = "4.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "mcp-types" },
     { name = "platformdirs" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
@@ -805,16 +806,16 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/b6/b5b9e81e67a3f39534881d2af6aa3fbd2dc367eaa070c3c932770a0c062f/fastmcp_slim-3.4.6.tar.gz", hash = "sha256:6a1e6e42c697ba90abcb1be617a26947d07316f13c6fa138ae7b0de24558e32c", size = 594167, upload-time = "2026-08-05T14:54:15.924Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/ec/c7d2f91ea6027fa92240ba25bb0d7601b9e1f5f5e69f079bb0ee203df403/fastmcp_slim-4.0.0b2.tar.gz", hash = "sha256:b222d52c4883695f2bafb973c6fd55694bbcc8eaaa64886ebb2168d0267add3c", size = 664066, upload-time = "2026-08-07T00:16:24.158Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/0b/02c254c46b4323ae5262b76a29af73b50a863efc5739a3454d144d3605ee/fastmcp_slim-3.4.6-py3-none-any.whl", hash = "sha256:3e08e6acb03523a47aa17f4d2ab9943e648a41e20b24084da491a732c46dffdc", size = 769174, upload-time = "2026-08-05T14:54:14.663Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/45/3aabf3cc93cda2e3ad580f75eba771371b4434bb7364be2781e3e5823bdc/fastmcp_slim-4.0.0b2-py3-none-any.whl", hash = "sha256:b96c96372713a2d1d504cc2913549a0201b985add128ddd5a5520faff6bc28ff", size = 833078, upload-time = "2026-08-07T00:16:22.717Z" },
 ]
 
 [package.optional-dependencies]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
@@ -825,7 +826,7 @@ server = [
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -924,40 +925,32 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
     { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "httpcore2" },
     { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -1294,7 +1287,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.4.2,<4.0.0" },
+    { name = "fastmcp", specifier = ">=4.0.0b2,<5.0.0" },
     { name = "libtmux", specifier = ">=0.62.0,<1.0" },
 ]
 
@@ -1478,15 +1471,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1496,9 +1489,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -3007,6 +3013,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Migrate** the FastMCP requirement to the 4.x prerelease line as a floor (`>=4.0.0b2,<5.0.0`) rather than an exact pin, so installs pick up 4.0.0 when it ships without another release here. FastMCP 4 brings MCP Python SDK v2 with it; no tool, resource, or prompt changes shape, and the server keeps serving whichever protocol era each client asks for.
- **Keep** `tmux://` reads working for tmux identifiers that look like filesystem paths. FastMCP 4 screens templated resource parameters before a handler runs, and its absolute-path check rejects both the socket paths `list_servers` reports and the `<letter>:<rest>` session names tmux accepts — while the equivalent tools resolve them fine.
- **Add** resource coverage for those shapes across every template, plus a guard that a `..` socket name is still refused.
- **Bind** the compatibility reference to the manifest, so the dependency table can no longer drift from `[project].dependencies`.
- **Retire** FastMCP's camelCase compatibility shims in the test suite, with enforcement, so a read that depends on a scheduled-for-removal alias fails the test that made it.
- **Replace** this package's one FastMCP internal import with the documented path, and correct three places that described an error-code transform that never happened.

## Try this branch

Two things differ from the installation methods on the front page. The source is a git ref rather than PyPI, and the FastMCP requirement resolves to a **prerelease**. The prerelease needs no opt-in flag — PEP 440 admits one when only a prerelease satisfies the specifier — but a uv `exclude-newer` cooldown will hide `fastmcp 4.0.0b2` until it ages past the window, which is what the `UV_NO_CONFIG` / `--exclude-newer-package` forms below are for. Drop them once the cooldown lapses, or if you have none configured.

Run it straight from the branch with uvx:

```console
$ uvx --no-config --from git+https://github.com/tmux-python/libtmux-mcp@fastmcp-v4.x libtmux-mcp
```

Keep your cooldown for every other package by exempting only these two distributions. Naming `fastmcp` alone is not enough — the resolver then stops on `fastmcp-slim`:

```console
$ uvx \
    --exclude-newer-package fastmcp=false \
    --exclude-newer-package fastmcp-slim=false \
    --from git+https://github.com/tmux-python/libtmux-mcp@fastmcp-v4.x \
    libtmux-mcp
```

pipx resolves through uv when its uv backend is available, so it inherits the same cooldown. `UV_NO_CONFIG` clears it; `PIPX_DISABLE_UV` does not:

```console
$ UV_NO_CONFIG=1 pipx run --spec git+https://github.com/tmux-python/libtmux-mcp@fastmcp-v4.x libtmux-mcp
```

pip has no cooldown of its own, so it needs nothing extra:

```console
$ pip install git+https://github.com/tmux-python/libtmux-mcp@fastmcp-v4.x
```

From a local checkout, `UV_FROZEN` stops uv re-resolving against the cooldown — the committed lockfile already pins the right versions:

```console
$ UV_FROZEN=1 uv --directory ~/work/python/libtmux-mcp run libtmux-mcp
```

### Registering it with an agent

Substitute one of the commands above for `<CMD>`. Give the server a distinct name if you already have `tmux` registered against a release, so the two cannot collide:

```console
$ claude mcp add tmuxlab -- uvx --no-config --from git+https://github.com/tmux-python/libtmux-mcp@fastmcp-v4.x libtmux-mcp
```

```console
$ codex mcp add tmuxlab -- <CMD>
```

```console
$ grok mcp add --scope user tmuxlab -- <CMD>
```

For the JSON-configured clients — Claude Desktop, Cursor, Antigravity — the cooldown bypass rides as an `env` member:

```json
{
  "mcpServers": {
    "tmuxlab": {
      "command": "uvx",
      "args": ["--from", "git+https://github.com/tmux-python/libtmux-mcp@fastmcp-v4.x", "libtmux-mcp"],
      "env": { "UV_NO_CONFIG": "1" }
    }
  }
}
```

To exercise it without touching a real config, Claude Code takes a throwaway one for the session:

```console
$ claude --mcp-config ./lab.json --strict-mcp-config --permission-mode bypassPermissions
```

Codex reads `CODEX_HOME`, Grok reads `GROK_HOME`, Gemini and Cursor read a project config, and Antigravity takes `--gemini_dir`.

### The check that exercises what this PR changes

Point the server at a scratch socket and create the session name FastMCP 4's screen rejects:

```console
$ tmux -L mcp-target new-session -d -s 'a:1'
```

Then ask the agent to read the **resource**, not the tool — the tool path was never affected:

> Read the MCP resource `tmux://sessions` and list the session names.

On this branch the read returns `a:1`. Against FastMCP 4 without this change it fails with `Resource not found`, while `get_session_info(session_name="a:1")` still resolves the same session — the disagreement between the two views is what this closes.

## Changes by area

### Dependency

**`pyproject.toml`**: FastMCP moves to `>=4.0.0b2,<5.0.0`. No `[tool.uv]` block and no `exclude-newer-package` entries are added — FastMCP pins `fastmcp-slim` in its own metadata, so no constraint is needed, and cooldown exemptions are a local-machine concern that would otherwise be committed as policy against this project's most security-sensitive third-party dependencies.

### Resource screening

**`src/libtmux_mcp/server.py`**: Turns off the absolute-path screen for resource parameters, keeping traversal and null-byte screening.

**`tests/test_resources_integration.py`**: Reads every template with an absolute socket path and a path-shaped session name, checks the resource and tool views agree on such a session, and pins that a `..` socket name never reaches tmux.

### Documentation drift

**`tests/docs/test_compatibility.py`**: Compares the documented dependency ranges against the manifest as `SpecifierSet` values, so the doc stays free to space them differently, and fails when a runtime dependency has no row or a row has no dependency.

**`docs/reference/compatibility.md`**: States the floors the manifest actually requires.

### Deprecation debt

**`conftest.py`**: Disables FastMCP's camelCase bridge for the suite, set through the environment before anything imports FastMCP so the subprocess-based tests inherit it.

**`tests/conftest.py`**: Adds `wire_input_schema`, a sibling of the existing `wire_annotations`, reading a tool's argument schema under its protocol name.

## Design decisions

**A prerelease floor, not an exact pin.** `fastmcp==4.0.0b2` installs today — PEP 440 admits a prerelease when only a prerelease satisfies the specifier — but it is sticky: once 4.0.0 ships, every consumer is still on a beta, and the pin becomes a hard resolver conflict with anything asking for `fastmcp>=4.0.0`. A floor self-migrates. Verified on the released line, where `fastmcp>=3.4.0b1,<4` resolves to `3.4.6` rather than the beta.

**`reject_absolute_paths=False`, not `exempt_params` or `resource_security=None`.** The SDK docstring suggests exempting parameters, and both alternatives fix the regression. Neither is right here. `socket_name` arrives through the `{?socket_name}` query, which URI normalization does not touch — unlike path segments, where `..` is collapsed before the handler runs — and it reaches `tmux -L` unvalidated, where a `../..` prefix really does place the socket outside the tmux socket directory:

```console
$ tmux -L '../../tmp/escaped' new-session -d 'sleep 30'
```

An absolute `-L` value cannot escape, because tmux concatenates rather than resolves. So the absolute-path check has no true positive here and two false positives, while the traversal check has a live one. Exempting the parameter, or disabling screening wholesale, would discard the check that still means something. `test_socket_name_traversal_never_reaches_tmux` fails under both alternatives and passes under the chosen one, so the decision is pinned by a test rather than a comment.

**Wire names over Python attribute spellings.** The camelCase migration reads schemas through `model_dump(by_alias=True)` rather than the SDK's `input_schema`. The Python spelling differs across SDK majors while the wire name is what the protocol guarantees and what a client actually sees, so this survives the next rename. It is the idiom `wire_annotations` already established here.

**Enforcement through the environment, not the settings object.** FastMCP builds its settings singleton at import, so the toggle has to precede it; and the schema tests spawn subprocesses through `os.environ.copy()`, which inherits an environment variable but not an attribute assignment. Neither existing gate catches a read that depends on the shims: the type checker sees `Any`, because the SDK objects arrive through `Client.__aenter__`, which is unannotated in both FastMCP 3 and 4; and the deprecation warning fires once per attribute for a whole run.

## Verification

No FastMCP internal module remains imported:

```console
$ rg -n 'fastmcp\.tools\.base|fastmcp\.server\.proxy|fastmcp\.server\.openapi|fastmcp\.server\.apps' src/ tests/
```

No camelCase SDK attribute read survives (matches in prose and the `by_alias` dump key are expected; an attribute access is not):

```console
$ rg -n '\.inputSchema|\.outputSchema|\.isError|\.structuredContent|\.mimeType|\.nextCursor' src/ tests/
```

No surface removed in FastMCP 4 is used:

```console
$ rg -n 'ctx\.sample|list_roots|import_server|as_proxy|exclude_args|sampling_handler|task=True' src/
```

The manifest carries no committed cooldown exemption for the FastMCP or MCP distributions:

```console
$ rg -n -A 30 'exclude-newer-package' pyproject.toml | rg '^\s*(fastmcp|fastmcp-slim|mcp|mcp-types) = '
```

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` — clean
- [x] `uv run ruff format .` — no reformatting
- [x] `uv run mypy src tests` — clean under FastMCP 4
- [x] `uv run py.test --reruns 0` — full suite green
- [x] `just build-docs` — builds with no new warning and no broken cross-reference
- [x] `test_resource_read_accepts_path_like_parameters` — every `tmux://` template reads with an absolute socket path and a colon-bearing session name; fails on every template without the screening change
- [x] `test_resource_and_tool_agree_on_path_like_session_names` — a session readable through `get_session_info` is readable through `tmux://`
- [x] `test_socket_name_traversal_never_reaches_tmux` — a `..` socket name is refused and no server is cached for it; fails under both `exempt_params` and `resource_security=None`, which is what makes it a decision record
- [x] `test_compatibility_dependency_floors_match_the_manifest` — fails when the documented range is edited away from the manifest
- [x] `test_camelcase_bridge_is_disabled_for_the_suite` — asserts the bridge is off, so an import-order change fails loudly rather than quietly restoring the safety net
- [x] Reintroducing a camelCase attribute read raises `AttributeError` and fails its test, rather than passing with a warning
- [x] Real Claude Code, over stdio against this branch, reads `tmux://sessions` and returns a session named `a:1` — the shape that the unmodified FastMCP 4 screen rejects
- [x] `uvx`, `pipx`, and `pip` each install and launch the console script from this branch's git ref

## Companion PR

The documentation toolchain needs a matching change before this branch's rendered docs are correct. `sphinx-autodoc-fastmcp` strips FastMCP's auto-appended prompt-argument schema hint by literal prefix match, and FastMCP 4 reworded it, so the boilerplate now renders in the prompts page. The build stays green and emits no warning, so nothing here catches it.

The fix belongs in `gp-sphinx`, and must match **both** wordings rather than swap one for the other — the same released collector serves repositories on either FastMCP major:

| FastMCP | Emitted prefix |
|---|---|
| 3.x | `Provide as a JSON string matching the following schema:` |
| 4.x | `Provide a value matching the following JSON schema:` |
